### PR TITLE
Fix stats grid icons

### DIFF
--- a/src/components/dashboard/trainee/StatsGrid.tsx
+++ b/src/components/dashboard/trainee/StatsGrid.tsx
@@ -10,9 +10,9 @@ import {
 } from '@mui/material';
 import InfoIcon from '@mui/icons-material/Info';
 import type { TrainingStats } from '../../../types/training';
-import completionImage from '../../../assets/completion.svg';
-import averageImage from '../../../assets/average.svg';
-import highestImage from '../../../assets/highest.svg';
+import completionImage from '../../../assets/completion.svg?url';
+import averageImage from '../../../assets/average.svg?url';
+import highestImage from '../../../assets/highest.svg?url';
 
 interface StatsGridProps {
   stats: TrainingStats;
@@ -79,21 +79,21 @@ const StatsGrid: React.FC<StatsGridProps> = ({ stats }) => {
       title: 'On Time Completion',
       value: `${stats.timely_completion.percentage}%`,
       subtitle: `${stats.timely_completion.completed_simulations} simulations`,
-      backgroundIcon: "../../../src/assets/completion.svg",
+      backgroundIcon: completionImage,
       tooltip:
         'On-time completed test simulations / total number of test simulations completed.',
     },
     {
       title: 'Average Sim Score',
       value: `${stats.average_sim_score}%`,
-      backgroundIcon: "../../../src/assets/average.svg",
+      backgroundIcon: averageImage,
       tooltip:
         'Average simulation score for all the completed simulations in test attempt.',
     },
     {
       title: 'Highest Sim Score',
       value: `${stats.highest_sim_score}%`,
-      backgroundIcon: "../../../src/assets/highest.svg",
+      backgroundIcon: highestImage,
       tooltip:
         'Highest simulation score of all the completed simulations in test attempt.',
     },

--- a/src/components/dashboard/trainee/playback/PlaybackStats.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackStats.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { Stack, Grid, Typography, Card, CardContent, Box } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
-import completionImage from "../../../../assets/completion.svg";
-import averageImage from "../../../../assets/average.svg";
-import highestImage from "../../../../assets/highest.svg";
+import completionImage from "../../../../assets/completion.svg?url";
+import averageImage from "../../../../assets/average.svg?url";
+import highestImage from "../../../../assets/highest.svg?url";
 import { useAuth } from "../../../../context/AuthContext";
 import {
   fetchPlaybackStats,
@@ -40,21 +40,21 @@ const stats: StatData[] = [
     value: "74%",
     subtitle: "16 simulations",
     icon: <InfoIcon sx={{ fontSize: 20 }} />,
-    backgroundIcon: "/src/assets/completion.svg",
+    backgroundIcon: completionImage,
   },
   {
     title: "Average Sim Score",
     value: "89%",
     trend: { value: -4, label: "vs last week" },
     icon: <InfoIcon sx={{ fontSize: 20 }} />,
-    backgroundIcon: "/src/assets/average.svg",
+    backgroundIcon: averageImage,
   },
   {
     title: "Highest Sim Score",
     value: "94%",
     trend: { value: 2, label: "vs last week" },
     icon: <InfoIcon sx={{ fontSize: 20 }} />,
-    backgroundIcon: "/src/assets/highest.svg",
+    backgroundIcon: highestImage,
   },
 ];
 
@@ -292,3 +292,4 @@ const PlaybackStats = ({ setGlobalLoading }: PlaybackStatsProps) => {
 };
 
 export default PlaybackStats;
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     // keep this block if you still want to add other dev-server options later
   },
   build: {
+    assetsInlineLimit: 0,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary
- make asset imports use `?url` so SVGs get emitted
- set `assetsInlineLimit: 0` so small icons are written to `dist`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`
