### PR TITLE
Default estimated time toggle off

### DIFF
--- a/src/components/dashboard/trainee/manage/generate/GenerateScript.tsx
+++ b/src/components/dashboard/trainee/manage/generate/GenerateScript.tsx
@@ -354,9 +354,9 @@ const GenerateScriptContent = () => {
             prompt: simulation.prompt || "",
             levels: mappedLevels,
             // Map all other fields from the API response
-            est_time: simulation.est_time || "15",
+            est_time: simulation.est_time || "",
             estimated_time_to_attempt_in_mins:
-              simulation.estimated_time_to_attempt_in_mins || 15,
+              simulation.estimated_time_to_attempt_in_mins,
             key_objectives: simulation.key_objectives || [
               "Learn basic customer service",
               "Understand refund process",

--- a/src/components/dashboard/trainee/manage/generate/settingTab/AdvancedSetting.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/AdvancedSetting.tsx
@@ -218,7 +218,7 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
       ),
       estimatedTime: {
         enabled: settings.estimatedTime?.enabled || false,
-        value: settings.estimatedTime?.value || "10 mins",
+        value: settings.estimatedTime?.value || "",
       },
       objectives: {
         enabled: settings.objectives?.enabled || false,

--- a/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
@@ -306,12 +306,14 @@ const SettingTab: React.FC<SettingTabProps> = ({
 
     // Get estimated time (convert from minutes to "X mins" format)
     const estimatedTime = {
-      enabled: true,
+      enabled:
+        simulationData?.estimated_time_to_attempt_in_mins !== undefined ||
+        simulationData?.est_time !== undefined,
       value: simulationData?.estimated_time_to_attempt_in_mins
         ? `${simulationData.estimated_time_to_attempt_in_mins} mins`
         : simulationData?.est_time
           ? `${simulationData.est_time} mins`
-          : "15 mins",
+          : "",
     };
 
     // FIXED: Properly handle objectives from API
@@ -637,8 +639,8 @@ const SettingTab: React.FC<SettingTabProps> = ({
     // Extract specific settings - ensure we're accessing the actual properties
     const levelSettings = advancedSettings?.levels || {};
     const timeSettings = advancedSettings?.estimatedTime || {
-      enabled: true,
-      value: "15 mins",
+      enabled: false,
+      value: "",
     };
     const objectivesSettings = advancedSettings?.objectives || {
       enabled: false,
@@ -653,7 +655,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
 
     // Parse time value to extract just the number
     const timeValue =
-      String(timeSettings.value || "15").match(/\d+/)?.[0] || "15";
+      String(timeSettings.value || "").match(/\d+/)?.[0] || "";
 
     // Check enabled levels from simulationLevels setting
     const lvl1Enabled = levelSettings.simulationLevels?.lvl1 !== false; // Default to true if undefined
@@ -776,9 +778,10 @@ const SettingTab: React.FC<SettingTabProps> = ({
         ai_powered_pauses_and_feedback:
           levelSettings.aiPoweredPauses?.lvl3 === true,
       },
-      estimated_time_to_attempt_in_mins: timeSettings.enabled
-        ? parseInt(timeValue)
-        : 0,
+      estimated_time_to_attempt_in_mins:
+        timeSettings.enabled && timeValue !== ""
+          ? parseInt(timeValue)
+          : 0,
       // CRITICAL FIX: Only send objectives if enabled, otherwise send empty array
       key_objectives: objectivesSettings.enabled
         ? processTextToArray(objectivesSettings.text)


### PR DESCRIPTION
## Summary
- disable estimated time toggle on new simulations
- require user to select a time before publish

## Testing
- `npm run lint` *(fails: Invalid option and many lint errors)*
- `npx eslint .` *(fails with 556 problems)*
- `npm run build`