### PR TITLE
Use trainee avatar in script panels

### DIFF
--- a/src/components/dashboard/trainee/manage/generate/PreviewTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/PreviewTab.tsx
@@ -12,6 +12,7 @@ import {
   Fade,
   CircularProgress,
 } from "@mui/material";
+import { useAuth } from "../../../../../context/AuthContext";
 import {
   HeadsetMic,
   PlayArrow,
@@ -166,6 +167,7 @@ const PreviewTab: React.FC<PreviewTabProps> = ({
   const [simulationData, setSimulationData] = useState<SimulationData | null>(
     null,
   );
+  const { user } = useAuth();
   const [slides, setSlides] = useState<Map<string, string>>(new Map());
   const [isCallActive, setIsCallActive] = useState(false);
   const [allMessages, setAllMessages] = useState<Message[]>([]);
@@ -856,9 +858,18 @@ const PreviewTab: React.FC<PreviewTabProps> = ({
                     </Box>
                     {message.speaker === "trainee" && (
                       <Avatar
-                        src="https://images.unsplash.com/photo-1494790108377-be9c29b29330"
+                        src={user?.profileImageUrl || undefined}
                         sx={{ width: 32, height: 32 }}
-                      />
+                      >
+                        {!user?.profileImageUrl &&
+                          (user?.name
+                            ? user.name
+                                .split(" ")
+                                .map((n) => n[0])
+                                .join("")
+                                .toUpperCase()
+                            : "T")}
+                      </Avatar>
                     )}
                   </Stack>
                 ))}

--- a/src/components/dashboard/trainee/manage/generate/ScriptEditor.tsx
+++ b/src/components/dashboard/trainee/manage/generate/ScriptEditor.tsx
@@ -37,6 +37,7 @@ import {
   Send as SendIcon,
   Refresh as RefreshIcon,
 } from "@mui/icons-material";
+import { useAuth } from "../../../../../context/AuthContext";
 
 // Import the AudioRecorder component
 import AudioRecorder from "./AudioRecorder";
@@ -144,6 +145,7 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({
   onScriptUpdate,
 }) => {
   const theme = useTheme();
+  const { user } = useAuth();
 
   // ----------------------------
   //   State
@@ -900,9 +902,18 @@ const ScriptEditor: React.FC<ScriptEditorProps> = ({
                   {/* Trainee avatar on right */}
                   {msg.role === "Trainee" && (
                     <Avatar
-                      src="https://images.unsplash.com/photo-1494790108377-be9c29b29330"
+                      src={user?.profileImageUrl || undefined}
                       sx={{ width: 32, height: 32 }}
-                    />
+                    >
+                      {!user?.profileImageUrl &&
+                        (user?.name
+                          ? user.name
+                              .split(" ")
+                              .map((n) => n[0])
+                              .join("")
+                              .toUpperCase()
+                          : "T")}
+                    </Avatar>
                   )}
                 </Stack>
               </DraggableMessage>

--- a/src/components/dashboard/trainee/manage/generate/settingTab/PreviewTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/PreviewTab.tsx
@@ -17,6 +17,7 @@ import {
   SmartToy as SmartToyIcon,
 } from '@mui/icons-material';
 import axios from 'axios';
+import { useAuth } from '../../../../../../context/AuthContext';
 import { RetellWebClient } from 'retell-client-js-sdk';
 
 interface Message {
@@ -37,6 +38,7 @@ const PreviewTab: React.FC<PreviewTabProps> = ({ simulationId, simulationType = 
   const [isStarting, setIsStarting] = useState(false);
   const [inputMessage, setInputMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const { user } = useAuth();
   const previousTranscriptRef = useRef<{ role: string; content: string }[]>([]);
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
@@ -308,9 +310,18 @@ const PreviewTab: React.FC<PreviewTabProps> = ({ simulationId, simulationType = 
                       </Box>
                       {message.speaker === 'trainee' && (
                         <Avatar
-                          src="https://images.unsplash.com/photo-1494790108377-be9c29b29330"
+                          src={user?.profileImageUrl || undefined}
                           sx={{ width: 32, height: 32 }}
-                        />
+                        >
+                          {!user?.profileImageUrl &&
+                            (user?.name
+                              ? user.name
+                                  .split(' ')
+                                  .map((n) => n[0])
+                                  .join('')
+                                  .toUpperCase()
+                              : 'T')}
+                        </Avatar>
                       )}
                     </Stack>
                   ))}

--- a/src/components/dashboard/trainee/playback/detail/PlaybackChat.tsx
+++ b/src/components/dashboard/trainee/playback/detail/PlaybackChat.tsx
@@ -8,6 +8,7 @@ import {
   Chip,
   Divider,
 } from "@mui/material";
+import { useAuth } from "../../../../../context/AuthContext";
 import PlaybackControls from "./PlaybackControls";
 
 interface Message {
@@ -56,6 +57,7 @@ interface PlaybackChatProps {
 }
 
 const PlaybackChat = ({ messages }: PlaybackChatProps) => {
+  const { user } = useAuth();
   useEffect(() => {
     console.log("messages ----playbck-", messages);
   }, [messages]);
@@ -230,9 +232,18 @@ const PlaybackChat = ({ messages }: PlaybackChatProps) => {
               </Box>
               {message.type === "agent" && (
                 <Avatar
-                  src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=crop&w=256&h=256&q=80"
+                  src={user?.profileImageUrl || undefined}
                   sx={{ width: 32, height: 32 }}
-                />
+                >
+                  {!user?.profileImageUrl &&
+                    (user?.name
+                      ? user.name
+                          .split(" ")
+                          .map((n) => n[0])
+                          .join("")
+                          .toUpperCase()
+                      : "T")}
+                </Avatar>
               )}
             </Stack>
           ))}

--- a/src/components/dashboard/trainee/simulation/AudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/AudioSimulationPage.tsx
@@ -762,9 +762,18 @@ const AudioSimulationPage: React.FC<AudioSimulationPageProps> = ({
                       </Box>
                       {message.speaker === "trainee" && (
                         <Avatar
-                          src="https://images.unsplash.com/photo-1494790108377-be9c29b29330"
+                          src={user?.profileImageUrl || undefined}
                           sx={{ width: 32, height: 32 }}
-                        />
+                        >
+                          {!user?.profileImageUrl &&
+                            (user?.name
+                              ? user.name
+                                  .split(" ")
+                                  .map((n) => n[0])
+                                  .join("")
+                                  .toUpperCase()
+                              : "T")}
+                        </Avatar>
                       )}
                     </Stack>
                   ))}

--- a/src/components/dashboard/trainee/simulation/ChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/ChatSimulationPage.tsx
@@ -533,9 +533,18 @@ const ChatSimulationPage: React.FC<ChatSimulationPageProps> = ({
                       </Box>
                       {message.speaker === "trainee" && (
                         <Avatar
-                          src="https://images.unsplash.com/photo-1494790108377-be9c29b29330"
+                          src={user?.profileImageUrl || undefined}
                           sx={{ width: 32, height: 32 }}
-                        />
+                        >
+                          {!user?.profileImageUrl &&
+                            (user?.name
+                              ? user.name
+                                  .split(" ")
+                                  .map((n) => n[0])
+                                  .join("")
+                                  .toUpperCase()
+                              : "T")}
+                        </Avatar>
                       )}
                     </Stack>
                   ))}

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -2185,13 +2185,21 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
 
                       {message.role === "trainee" && (
                         <Avatar
+                          src={user?.profileImageUrl || undefined}
                           sx={{
                             width: 28, // Reduced from 32
                             height: 28, // Reduced from 32
-                            bgcolor: "success.light",
+                            bgcolor: user?.profileImageUrl ? undefined : "success.light",
                           }}
                         >
-                          <PersonIcon fontSize="small" />
+                          {!user?.profileImageUrl &&
+                            (user?.name
+                              ? user.name
+                                  .split(" ")
+                                  .map((n) => n[0])
+                                  .join("")
+                                  .toUpperCase()
+                              : "T")}
                         </Avatar>
                       )}
                     </Stack>


### PR DESCRIPTION
## Summary
- display trainee's profile avatar instead of a placeholder image in chat and audio simulation pages
- use trainee avatar in script editing pages and playback chat

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`
- `npx tsc -p tsconfig.json`