### PR TITLE
Switch TTS playback to backend streaming

### DIFF
--- a/src/services/text_to_speech.ts
+++ b/src/services/text_to_speech.ts
@@ -1,0 +1,15 @@
+import apiClient from "./api/interceptors";
+
+export interface TextToSpeechRequest {
+  text: string;
+  voice_id?: string;
+}
+
+export const textToSpeech = async (
+  params: TextToSpeechRequest,
+): Promise<Blob> => {
+  const response = await apiClient.post<Blob>("/text-to-speech", params, {
+    responseType: "blob",
+  });
+  return response.data;
+};


### PR DESCRIPTION
## Summary
- add a `textToSpeech` API service for ElevenLabs streaming
- replace browser speech synthesis in `VisualAudioSimulationPage` with backend audio streaming

## Testing
- `npm run lint` *(fails: Invalid option `--ext`)*