### PR TITLE
Fix isClicked flag for dropdown hotspots

### DIFF
--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -839,36 +839,42 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
       // Check if current item is a hotspot that should be marked as clicked
       if (currentItem && currentItem.type === "hotspot") {
+        const hotspotType = currentItem.hotspotType || "";
+        // Only mark as clicked for button, highlight, and checkbox hotspots
+        const shouldSetIsClicked = ["button", "highlight", "checkbox"].includes(
+          hotspotType,
+        );
+
         // Find if this item is already in our data
         const itemIndex = finalAttemptData.findIndex(
           (item) => item.id === currentItem.id,
         );
 
         if (itemIndex >= 0) {
-          // Ensure it's marked as clicked and has the last wrong click removed
           const existingItem = finalAttemptData[itemIndex];
+          const { isClicked: _prevClicked, ...restExisting } = existingItem;
           let updatedWrongClicks = [...(existingItem.wrong_clicks || [])];
-          if (updatedWrongClicks.length > 0) {
+          if (shouldSetIsClicked && updatedWrongClicks.length > 0) {
             // Remove the last wrong click (which would be the correct click on the hotspot)
             updatedWrongClicks.pop();
           }
 
           finalAttemptData[itemIndex] = {
-            ...existingItem,
-            isClicked: true,
+            ...restExisting,
+            ...(shouldSetIsClicked ? { isClicked: true } : {}),
             wrong_clicks: updatedWrongClicks,
           };
           console.log(
-            "Final data updated for last hotspot:",
-            finalAttemptData[itemIndex],
+            `Final data updated for last hotspot ${currentItem.id}, type: ${hotspotType}, setting isClicked: ${shouldSetIsClicked}`,
           );
         } else {
           // Add it if not found
-          finalAttemptData.push({
-            ...currentItem,
-            isClicked: true,
-            wrong_clicks: [],
-          });
+          const { isClicked: _clicked, ...restCurrent } = currentItem;
+          finalAttemptData.push(
+            shouldSetIsClicked
+              ? { ...restCurrent, isClicked: true, wrong_clicks: [] }
+              : { ...restCurrent, wrong_clicks: [] },
+          );
         }
       }
 
@@ -1249,6 +1255,8 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
         // Make a copy of the data
         const newData = [...prevData];
         const existingItem = newData[existingItemIndex];
+        // Remove any previous isClicked flag when not applicable
+        const { isClicked: _prevClicked, ...restExisting } = existingItem;
 
         // Only update wrong_clicks for clickable hotspots
         let updatedWrongClicks = [...(existingItem.wrong_clicks || [])];
@@ -1259,7 +1267,7 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
         // Update the item, only setting isClicked for appropriate types
         newData[existingItemIndex] = {
-          ...existingItem,
+          ...restExisting,
           ...(shouldSetIsClicked ? { isClicked: true } : {}),
           wrong_clicks: updatedWrongClicks,
         };
@@ -1270,10 +1278,12 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
         return newData;
       } else {
         // If item doesn't exist yet, add it with appropriate properties
+        // Remove isClicked from currentItem if present
+        const { isClicked: _clicked, ...restCurrent } = currentItem;
         return [
           ...prevData,
           {
-            ...currentItem,
+            ...restCurrent,
             ...(shouldSetIsClicked ? { isClicked: true } : {}),
             wrong_clicks: [], // Start with empty wrong_clicks
           },
@@ -1327,10 +1337,11 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
     setAttemptSequenceData((prevData) => {
       const existingItem = prevData.find((item) => item.id === currentItem.id);
       if (existingItem) {
+        const { isClicked: _prevClicked, ...restExisting } = existingItem;
         return [
           ...prevData.filter((item) => item.id !== currentItem.id),
           {
-            ...existingItem,
+            ...restExisting,
             // Do NOT set isClicked for dropdown
             userInput: option,
             // Clear any wrong_clicks for dropdown
@@ -1338,10 +1349,11 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
           },
         ];
       } else {
+        const { isClicked: _clicked, ...restCurrent } = currentItem;
         return [
           ...prevData,
           {
-            ...currentItem,
+            ...restCurrent,
             // Do NOT set isClicked for dropdown
             userInput: option,
             wrong_clicks: [],
@@ -1882,6 +1894,7 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
         if (itemIndex >= 0) {
           // Update the item based on its type
           const existingItem = finalAttemptData[itemIndex];
+          const { isClicked: _prevClicked, ...restExisting } = existingItem;
 
           // For clickable hotspots, update isClicked and clean wrong_clicks
           if (shouldSetIsClicked) {
@@ -1892,14 +1905,14 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
             }
 
             finalAttemptData[itemIndex] = {
-              ...existingItem,
+              ...restExisting,
               isClicked: true,
               wrong_clicks: updatedWrongClicks,
             };
           } else {
             // For dropdown and textfield, don't set isClicked but clear wrong_clicks
             finalAttemptData[itemIndex] = {
-              ...existingItem,
+              ...restExisting,
               wrong_clicks: [],
             };
           }
@@ -1909,15 +1922,16 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
           );
         } else {
           // Add it if not found, with proper properties based on type
+          const { isClicked: _clicked, ...restCurrent } = currentItem;
           finalAttemptData.push(
-            shouldSetIsClicked 
+            shouldSetIsClicked
               ? {
-                  ...currentItem,
+                  ...restCurrent,
                   isClicked: true,
                   wrong_clicks: [],
                 }
               : {
-                  ...currentItem,
+                  ...restCurrent,
                   wrong_clicks: [],
                 }
           );


### PR DESCRIPTION
## Summary
- strip `isClicked` when updating dropdown hotspots
- keep `isClicked` removal on end call logic

## Testing
- `npm run lint` *(fails: Invalid option '--ext' due to ESLint config)*