### PR TITLE
Fix workspace persistence across routes

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate, Link as RouterLink, useLocation } from 'react-router-dom';
 import { TextField, Button, Paper, Typography, Container, Link } from '@mui/material';
 import { useAuth } from '../context/AuthContext';
+import { buildPathWithWorkspace } from '../utils/navigation';
 import api from '../services/api';
 import { useRedirectIfAuthenticated } from '../hooks/useRedirectIfAuthenticated';
 
@@ -10,7 +11,7 @@ const Login = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const { login, currentWorkspaceId } = useAuth();
+  const { login, currentWorkspaceId, currentTimeZone } = useAuth();
   const location = useLocation();
 
   // Redirect if already authenticated
@@ -23,12 +24,13 @@ const Login = () => {
     try {
       const response = await api.login({ email, password });
 
-      // Get workspace ID from URL or use the one from context
+      // Get workspace ID and timeZone from URL or context
       const params = new URLSearchParams(location.search);
       const workspaceId = params.get('workspace_id') || currentWorkspaceId;
+      const timeZone = params.get('timeZone') || currentTimeZone;
 
-      login(response.token, workspaceId || undefined);
-      navigate('/dashboard');
+      login(response.token, workspaceId || undefined, timeZone || undefined);
+      navigate(buildPathWithWorkspace('/dashboard', workspaceId, timeZone));
     } catch (err: any) {
       setError(err.response?.data?.message || 'An error occurred during login');
     }
@@ -76,7 +78,11 @@ const Login = () => {
           </Button>
           <Typography align="center">
             Don't have an account?{' '}
-            <Link component={RouterLink} to="/register" underline="hover">
+            <Link
+              component={RouterLink}
+              to={buildPathWithWorkspace('/register', currentWorkspaceId, currentTimeZone)}
+              underline="hover"
+            >
               Register here
             </Link>
           </Typography>

--- a/src/components/Register.tsx
+++ b/src/components/Register.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate, Link as RouterLink, useLocation } from 'react-router-dom';
 import { TextField, Button, Paper, Typography, Container, MenuItem, Link } from '@mui/material';
 import { useAuth } from '../context/AuthContext';
+import { buildPathWithWorkspace } from '../utils/navigation';
 import api from '../services/api';
 import { UserRole } from '../types/auth';
 import { useRedirectIfAuthenticated } from '../hooks/useRedirectIfAuthenticated';
@@ -23,7 +24,7 @@ const Register = () => {
   });
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const { login, currentWorkspaceId } = useAuth();
+  const { login, currentWorkspaceId, currentTimeZone } = useAuth();
   const location = useLocation();
 
   // Redirect if already authenticated
@@ -40,12 +41,13 @@ const Register = () => {
     try {
       const response = await api.register(formData);
 
-      // Get workspace ID from URL or use the one from context
+      // Get workspace ID and timeZone from URL or context
       const params = new URLSearchParams(location.search);
       const workspaceId = params.get('workspace_id') || currentWorkspaceId;
+      const timeZone = params.get('timeZone') || currentTimeZone;
 
-      login(response.token, workspaceId || undefined);
-      navigate('/dashboard');
+      login(response.token, workspaceId || undefined, timeZone || undefined);
+      navigate(buildPathWithWorkspace('/dashboard', workspaceId, timeZone));
     } catch (err: any) {
       setError(err.response?.data?.message || 'An error occurred during registration');
     }
@@ -119,7 +121,11 @@ const Register = () => {
           </Button>
           <Typography align="center">
             Already have an account?{' '}
-            <Link component={RouterLink} to="/login" underline="hover">
+            <Link
+              component={RouterLink}
+              to={buildPathWithWorkspace('/login', currentWorkspaceId, currentTimeZone)}
+              underline="hover"
+            >
               Sign in here
             </Link>
           </Typography>

--- a/src/components/dashboard/trainee/SimulationAttemptPage.tsx
+++ b/src/components/dashboard/trainee/SimulationAttemptPage.tsx
@@ -29,6 +29,7 @@ import { fetchSimulationById } from "../../../services/simulations";
 import { canStartTest } from "../../../services/simulation";
 import { fetchTrainingData } from "../../../services/training";
 import { useAuth } from "../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../utils/navigation";
 import type { Simulation, TrainingData } from "../../../types/training";
 
 interface SimulationItem {
@@ -54,7 +55,7 @@ const SimulationAttemptPage = () => {
     assignment_id: string;
   }>();
   const navigate = useNavigate();
-  const { user, currentWorkspaceId } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
   const [selectedLevel, setSelectedLevel] = useState<string | null>(null);
   const [selectedAttempt, setSelectedAttempt] = useState<
     "Test" | "Practice" | null
@@ -209,12 +210,12 @@ const SimulationAttemptPage = () => {
     if (index < 0 || index >= allSimulations.length) return;
 
     const sim = allSimulations[index];
-    const workspaceParam = currentWorkspaceId
-      ? `?workspace_id=${currentWorkspaceId}`
-      : "";
-    navigate(
-      `/simulation/${sim.simulation_id}/${sim.assignment_id}/attempt${workspaceParam}`,
+    const path = buildPathWithWorkspace(
+      `/simulation/${sim.simulation_id}/${sim.assignment_id}/attempt`,
+      currentWorkspaceId,
+      currentTimeZone
     );
+    navigate(path);
   };
 
   const navigatePrevious = () => {

--- a/src/components/dashboard/trainee/TrainingItemsTable.tsx
+++ b/src/components/dashboard/trainee/TrainingItemsTable.tsx
@@ -37,6 +37,7 @@ import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import type { TrainingPlan, Module, Simulation } from "../../../types/training";
 import { useAuth } from "../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../utils/navigation";
 import DateSelector from "../../common/DateSelector";
 
 // Extend dayjs with plugins
@@ -318,19 +319,21 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
     event: React.MouseEvent,
   ) => {
     event.stopPropagation();
-    const workspaceParam = currentWorkspaceId
-      ? `?workspace_id=${currentWorkspaceId}`
-      : "";
-    navigate(
-      `/simulation/${simulationId}/${assignmentId}/attempt${workspaceParam}`,
+    const path = buildPathWithWorkspace(
+      `/simulation/${simulationId}/${assignmentId}/attempt`,
+      currentWorkspaceId,
+      currentTimeZone
     );
+    navigate(path);
   };
 
   const handleTrainingPlanClick = (trainingPlan: TrainingPlan) => {
-    const workspaceParam = currentWorkspaceId
-      ? `?workspace_id=${currentWorkspaceId}`
-      : "";
-    navigate(`/training/${trainingPlan.id}${workspaceParam}`, {
+    const path = buildPathWithWorkspace(
+      `/training/${trainingPlan.id}`,
+      currentWorkspaceId,
+      currentTimeZone
+    );
+    navigate(path, {
       state: { trainingPlan },
     });
   };

--- a/src/components/dashboard/trainee/WelcomeBanner.tsx
+++ b/src/components/dashboard/trainee/WelcomeBanner.tsx
@@ -4,6 +4,7 @@ import { Stack, Button, Typography, Box } from '@mui/material';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import { useTheme } from '@mui/material/styles';
 import { useAuth } from '../../../context/AuthContext';
+import { buildPathWithWorkspace } from '../../../utils/navigation';
 import type { TrainingData, Simulation } from '../../../types/training';
 import welcomeBannerImage from '../../../assets/banner.svg';
 
@@ -15,7 +16,7 @@ interface WelcomeBannerProps {
 const WelcomeBanner: React.FC<WelcomeBannerProps> = ({ userName, trainingData }) => {
   const theme = useTheme();
   const navigate = useNavigate();
-  const { currentWorkspaceId } = useAuth();
+  const { currentWorkspaceId, currentTimeZone } = useAuth();
 
   // Find the first simulation with "not_started" status
   const findNextSimulation = (): string | null => {
@@ -57,8 +58,12 @@ const WelcomeBanner: React.FC<WelcomeBannerProps> = ({ userName, trainingData })
   const handleGoToNextSimulation = () => {
     const nextSimulationId = findNextSimulation();
     if (nextSimulationId) {
-      const workspaceParam = currentWorkspaceId ? `?workspace_id=${currentWorkspaceId}` : '';
-      navigate(`/simulation/${nextSimulationId}/attempt${workspaceParam}`);
+      const path = buildPathWithWorkspace(
+        `/simulation/${nextSimulationId}/attempt`,
+        currentWorkspaceId,
+        currentTimeZone
+      );
+      navigate(path);
     } else {
       // If no simulation is found, we could show a message or navigate to a default page
       console.log('No pending simulations found');
@@ -66,8 +71,12 @@ const WelcomeBanner: React.FC<WelcomeBannerProps> = ({ userName, trainingData })
   };
 
   const handleGoToPlayback = () => {
-    const workspaceParam = currentWorkspaceId ? `?workspace_id=${currentWorkspaceId}` : '';
-    navigate(`/playback${workspaceParam}`);
+    const path = buildPathWithWorkspace(
+      '/playback',
+      currentWorkspaceId,
+      currentTimeZone
+    );
+    navigate(path);
   };
 
   return (

--- a/src/components/dashboard/trainee/manage/ActionsMenu.tsx
+++ b/src/components/dashboard/trainee/manage/ActionsMenu.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../../../utils/permissions";
 import { cloneSimulation } from "../../../../services/simulation_operations";
 import { useAuth } from "../../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../../utils/navigation";
 
 interface ActionsMenuProps {
   anchorEl: HTMLElement | null;
@@ -34,7 +35,7 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
   onCloneSuccess,
 }) => {
   const navigate = useNavigate();
-  const { user } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
   const [isCloning, setIsCloning] = useState(false);
 
   // Check permissions for different actions
@@ -44,7 +45,13 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
 
   const handleEditClick = () => {
     if (selectedRow) {
-      navigate(`/generate-scripts/${selectedRow.id}`);
+      navigate(
+        buildPathWithWorkspace(
+          `/generate-scripts/${selectedRow.id}`,
+          currentWorkspaceId,
+          currentTimeZone
+        )
+      );
     }
     onClose();
   };

--- a/src/components/dashboard/trainee/manage/CreateSimulationDialog.tsx
+++ b/src/components/dashboard/trainee/manage/CreateSimulationDialog.tsx
@@ -33,6 +33,7 @@ import {
 
 import { useForm, Controller } from "react-hook-form";
 import { useAuth } from "../../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../../utils/navigation";
 import {
   fetchDivisions,
   fetchDepartments,
@@ -91,7 +92,7 @@ const CreateSimulationDialog: React.FC<CreateSimulationDialogProps> = ({
   onClose,
 }) => {
   const navigate = useNavigate();
-  const { user, currentWorkspaceId } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [divisions, setDivisions] = useState<string[]>([]);
@@ -196,7 +197,13 @@ const CreateSimulationDialog: React.FC<CreateSimulationDialogProps> = ({
         // Close dialog
         onClose();
         // Navigate to the generate scripts page with the ID
-        navigate(`/generate-scripts/${response.id}`);
+        navigate(
+          buildPathWithWorkspace(
+            `/generate-scripts/${response.id}`,
+            currentWorkspaceId,
+            currentTimeZone
+          )
+        );
       } else {
         setErrorMessage("Failed to create simulation. Please try again.");
       }

--- a/src/components/dashboard/trainee/manage/generate/GenerateScript.tsx
+++ b/src/components/dashboard/trainee/manage/generate/GenerateScript.tsx
@@ -30,6 +30,7 @@ import {
   CompleteSimulationResponse,
 } from "../../../../../services/simulation_operations";
 import { useAuth } from "../../../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../../../utils/navigation";
 
 interface TabState {
   script: boolean;
@@ -341,7 +342,7 @@ const GenerateScriptContent = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const { user, currentWorkspaceId } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
 
   const {
     scriptData,
@@ -1242,7 +1243,15 @@ const GenerateScriptContent = () => {
           </Alert>
           <Button
             variant="contained"
-            onClick={() => navigate("/manage-simulations")}
+            onClick={() =>
+              navigate(
+                buildPathWithWorkspace(
+                  "/manage-simulations",
+                  currentWorkspaceId,
+                  currentTimeZone
+                )
+              )
+            }
             sx={{ mt: 2 }}
           >
             Back to Manage Simulations
@@ -1404,7 +1413,15 @@ const GenerateScriptContent = () => {
         </Alert>
         <Button
           variant="contained"
-          onClick={() => navigate("/manage-simulations")}
+          onClick={() =>
+            navigate(
+              buildPathWithWorkspace(
+                "/manage-simulations",
+                currentWorkspaceId,
+                currentTimeZone
+              )
+            )
+          }
           sx={{ mt: 2 }}
         >
           Back to Manage Simulations

--- a/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
@@ -26,6 +26,7 @@ import {
   updateSimulationWithFormData,
 } from "../../../../../../services/simulation_operations";
 import { useAuth } from "../../../../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../../../../utils/navigation";
 import { useSimulationWizard } from "../../../../../../context/SimulationWizardContext";
 
 const NavItem = styled(ListItem)(({ theme }) => ({
@@ -210,7 +211,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
   // Add state for weightage validation
   const [isWeightageValid, setIsWeightageValid] = useState(true);
 
-  const { user, currentWorkspaceId } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
   // Add state to track the edited prompt
   const [editedPrompt, setEditedPrompt] = useState(prompt);
 
@@ -1030,7 +1031,13 @@ const SettingTab: React.FC<SettingTabProps> = ({
     if (response) {
       if (response.status === "success" || response.status === "draft") {
         // Navigate to manage-simulations instead of showing preview
-        navigate("/manage-simulations");
+        navigate(
+          buildPathWithWorkspace(
+            "/manage-simulations",
+            currentWorkspaceId,
+            currentTimeZone
+          )
+        );
       } else {
         setError("Failed to save simulation as draft. Please try again.");
       }

--- a/src/components/dashboard/trainee/playback/PlaybackTable.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackTable.tsx
@@ -18,6 +18,7 @@ import {
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
 import { useAuth } from "../../../../context/AuthContext";
+import { buildPathWithWorkspace } from "../../../../utils/navigation";
 import {
   AttemptsResponse,
   fetchPlaybackRowData,
@@ -39,7 +40,7 @@ interface SimulationRecord {
 }
 
 const PlaybackTable = () => {
-  const { user } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
   const navigate = useNavigate();
 
   const [paginationParams, setPaginationParams] =
@@ -53,7 +54,12 @@ const PlaybackTable = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [error, setError] = useState<string | null>(null);
   const handleRowClick = (id: string) => {
-    navigate(`/playback/${id}`);
+    const path = buildPathWithWorkspace(
+      `/playback/${id}`,
+      currentWorkspaceId,
+      currentTimeZone
+    );
+    navigate(path);
   };
   const filteredData = useMemo(() => {
     if (!playbackData) return [];

--- a/src/components/dashboard/trainee/playback/detail/PlaybackHeader.tsx
+++ b/src/components/dashboard/trainee/playback/detail/PlaybackHeader.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Stack, Typography, Button } from '@mui/material';
+import { useAuth } from '../../../../../context/AuthContext';
+import { buildPathWithWorkspace } from '../../../../../utils/navigation';
 
 interface PlaybackHeaderProps {
   showDetails: boolean;
@@ -11,6 +13,7 @@ const PlaybackHeader: React.FC<PlaybackHeaderProps> = ({
   showDetails,
   onToggleDetails,
 }) => {
+  const { currentWorkspaceId, currentTimeZone } = useAuth();
   return (
     <Stack
       direction="row"
@@ -23,7 +26,14 @@ const PlaybackHeader: React.FC<PlaybackHeaderProps> = ({
       }}
     >
       <Stack direction="row" spacing={1} alignItems="center">
-        <Link to="/playback" style={{ textDecoration: 'none' }}>
+        <Link
+          to={buildPathWithWorkspace(
+            '/playback',
+            currentWorkspaceId,
+            currentTimeZone
+          )}
+          style={{ textDecoration: 'none' }}
+        >
           <Typography variant="h4" color="text.secondary">
             Playback
           </Typography>

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,18 @@
+export const buildPathWithWorkspace = (
+  basePath: string,
+  workspaceId?: string | null,
+  timeZone?: string | null
+): string => {
+  const params = new URLSearchParams();
+
+  if (workspaceId) {
+    params.set('workspace_id', workspaceId);
+  }
+
+  if (timeZone) {
+    params.set('timeZone', timeZone);
+  }
+
+  const queryString = params.toString();
+  return queryString ? `${basePath}?${queryString}` : basePath;
+};


### PR DESCRIPTION
## Summary
- add helper to build routes with workspace_id and timeZone
- append workspace parameters when navigating
- keep workspace ID and time zone in ProtectedRoute redirects

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`