### PR TITLE
Add simulation archive callback

### DIFF
--- a/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
@@ -772,7 +772,7 @@ const ManageSimulationsPage = () => {
               <Tab label="All" value="All" />
               <Tab label="Published" value="Published" />
               <Tab label="Draft" value="Draft" />
-              <Tab label="Archive" value="Archive" />
+              <Tab label="Archived" value="Archived" />
             </Tabs>
             <Button
               variant="contained"
@@ -1270,6 +1270,7 @@ const ManageSimulationsPage = () => {
         selectedRow={selectedRow}
         onClose={handleMenuClose}
         onCloneSuccess={loadSimulations}
+        onArchiveSuccess={loadSimulations}
       />
 
       <CreateSimulationDialog

--- a/src/components/dashboard/trainee/manage/types.ts
+++ b/src/components/dashboard/trainee/manage/types.ts
@@ -4,7 +4,7 @@ export interface SimulationData {
   version: string;
   level: string;
   type: string;
-  status: "Published" | "Draft" | "Archive";
+  status: "Published" | "Draft" | "Archived";
   tags: string[];
   estTime: string;
   lastModified: string;

--- a/src/services/simulation_operations.ts
+++ b/src/services/simulation_operations.ts
@@ -522,6 +522,60 @@ export const cloneSimulation = async (
   }
 };
 
+export interface ArchiveSimulationRequest {
+  user_id: string;
+  simulation_id: string;
+}
+
+export interface ArchiveSimulationResponse {
+  id: string;
+  status: string;
+}
+
+export const archiveSimulation = async (
+  userId: string,
+  simulationId: string,
+): Promise<ArchiveSimulationResponse> => {
+  try {
+    const payload: ArchiveSimulationRequest = {
+      user_id: userId,
+      simulation_id: simulationId,
+    };
+
+    const response = await apiClient.post<ArchiveSimulationResponse>(
+      "/simulations/archive",
+      payload,
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error("Error archiving simulation:", error);
+    throw error;
+  }
+};
+
+export const unarchiveSimulation = async (
+  userId: string,
+  simulationId: string,
+): Promise<ArchiveSimulationResponse> => {
+  try {
+    const payload: ArchiveSimulationRequest = {
+      user_id: userId,
+      simulation_id: simulationId,
+    };
+
+    const response = await apiClient.post<ArchiveSimulationResponse>(
+      "/simulations/unarchive",
+      payload,
+    );
+
+    return response.data;
+  } catch (error) {
+    console.error("Error unarchiving simulation:", error);
+    throw error;
+  }
+};
+
 export const detectMaskAreas = async (
   formData: FormData,
 ): Promise<DetectMaskPHIResponse[]> => {


### PR DESCRIPTION
## Summary
- wire a new `onArchiveSuccess` callback in `ActionsMenu`
- refresh simulations list after archiving

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`