### PR TITLE
Fix archive refresh

### DIFF
--- a/src/components/dashboard/trainee/manage/ActionsMenu.tsx
+++ b/src/components/dashboard/trainee/manage/ActionsMenu.tsx
@@ -100,7 +100,10 @@ const ActionsMenu: React.FC<ActionsMenuProps> = ({
 
     try {
       const response = await archiveSimulation(user.id, selectedRow.id);
-      if (response && response.status === "archived") {
+      if (
+        response &&
+        (response.status === "archived" || response.status === "success")
+      ) {
         console.log("Simulation archived successfully:", response);
         if (onArchiveSuccess) {
           onArchiveSuccess();


### PR DESCRIPTION
## Summary
- refresh page after archiving simulation like cloning

## Testing
- `npx eslint .` *(fails: lots of lint errors)*
- `npm run build`