### PR TITLE
Add unarchive option in manage simulations

### DIFF
--- a/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
@@ -1290,6 +1290,7 @@ const ManageSimulationsPage = () => {
         onClose={handleMenuClose}
         onCloneSuccess={refreshSimulations}
         onArchiveSuccess={refreshSimulations}
+        onUnarchiveSuccess={refreshSimulations}
       />
 
       <CreateSimulationDialog


### PR DESCRIPTION
## Summary
- show `Unarchive` action for archived simulations
- call backend to unarchive a simulation
- refresh table after unarchiving

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails with existing lint errors)*
- `npm run build`