### PR TITLE
Add archive support for training plans/modules

### DIFF
--- a/src/services/modules.ts
+++ b/src/services/modules.ts
@@ -5,6 +5,7 @@ export interface Module {
   name: string;
   tags: string[];
   simulations_id: string[];
+  status?: string;
   created_by: string;
   created_at: string;
   last_modified_by: string;
@@ -53,6 +54,7 @@ export interface ModulePaginationParams {
   createdBy?: string;
   tags?: string | string[];
   search?: string;
+  status?: string | string[];
 }
 
 export interface ModulesResponse {
@@ -165,6 +167,15 @@ export const fetchModules = async (
           payload.pagination.tags = [pagination.tags];
         }
       }
+
+      // Add optional status filter
+      if (pagination.status) {
+        if (Array.isArray(pagination.status)) {
+          payload.pagination.status = pagination.status;
+        } else if (pagination.status !== "All") {
+          payload.pagination.status = [pagination.status];
+        }
+      }
     }
 
     console.log('Fetching modules with payload:', payload);
@@ -221,6 +232,39 @@ export const updateModule = async (
     return response.data;
   } catch (error) {
     console.error(`Error updating module ${moduleId}:`, error);
+    throw error;
+  }
+};
+
+export interface ArchiveModuleResponse {
+  id: string;
+  status: string;
+}
+
+export const archiveModule = async (
+  userId: string,
+  moduleId: string
+): Promise<ArchiveModuleResponse> => {
+  try {
+    const payload = { user_id: userId, module_id: moduleId };
+    const response = await apiClient.post('/modules/archive', payload);
+    return response.data;
+  } catch (error) {
+    console.error('Error archiving module:', error);
+    throw error;
+  }
+};
+
+export const unarchiveModule = async (
+  userId: string,
+  moduleId: string
+): Promise<ArchiveModuleResponse> => {
+  try {
+    const payload = { user_id: userId, module_id: moduleId };
+    const response = await apiClient.post('/modules/unarchive', payload);
+    return response.data;
+  } catch (error) {
+    console.error('Error unarchiving module:', error);
     throw error;
   }
 };

--- a/src/services/trainingPlans.ts
+++ b/src/services/trainingPlans.ts
@@ -8,6 +8,7 @@ export interface TrainingPlan {
     type: 'module' | 'simulation';
     id: string;
   }>;
+  status?: string;
   created_by: string;
   created_at: string;
   last_modified_by: string;
@@ -65,6 +66,7 @@ export interface TrainingPlanPaginationParams {
   createdBy?: string;
   tags?: string | string[];
   search?: string;
+  status?: string | string[];
 }
 
 export interface TrainingPlansResponse {
@@ -166,6 +168,15 @@ export const fetchTrainingPlans = async (
           payload.pagination.tags = [pagination.tags];
         }
       }
+
+      // Add optional status filter
+      if (pagination.status) {
+        if (Array.isArray(pagination.status)) {
+          payload.pagination.status = pagination.status;
+        } else if (pagination.status !== "All") {
+          payload.pagination.status = [pagination.status];
+        }
+      }
     }
 
     console.log('Fetching training plans with payload:', payload);
@@ -227,6 +238,39 @@ export const updateTrainingPlan = async (
     return response.data;
   } catch (error) {
     console.error(`Error updating training plan ${trainingPlanId}:`, error);
+    throw error;
+  }
+};
+
+export interface ArchiveTrainingPlanResponse {
+  id: string;
+  status: string;
+}
+
+export const archiveTrainingPlan = async (
+  userId: string,
+  trainingPlanId: string
+): Promise<ArchiveTrainingPlanResponse> => {
+  try {
+    const payload = { user_id: userId, training_plan_id: trainingPlanId };
+    const response = await apiClient.post('/training-plans/archive', payload);
+    return response.data;
+  } catch (error) {
+    console.error('Error archiving training plan:', error);
+    throw error;
+  }
+};
+
+export const unarchiveTrainingPlan = async (
+  userId: string,
+  trainingPlanId: string
+): Promise<ArchiveTrainingPlanResponse> => {
+  try {
+    const payload = { user_id: userId, training_plan_id: trainingPlanId };
+    const response = await apiClient.post('/training-plans/unarchive', payload);
+    return response.data;
+  } catch (error) {
+    console.error('Error unarchiving training plan:', error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- implement archive/unarchive API calls for modules and training plans
- expose new archive functions in services
- enable archive/unarchive options in `TrainingPlanActionsMenu`
- add status filter and column to ManageTrainingPlan page
- pass item status to menu actions

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`