### PR TITLE
Fix archive menu visibility

### DIFF
--- a/src/components/dashboard/trainee/manage/TrainingPlanActionsMenu.tsx
+++ b/src/components/dashboard/trainee/manage/TrainingPlanActionsMenu.tsx
@@ -230,7 +230,7 @@ const TrainingPlanActionsMenu: React.FC<TrainingPlanActionsMenuProps> = ({
 
       {canCreate && <Divider sx={{ borderColor: '#EBEBEB' }} />}
 
-      {canUpdate && (
+      {canUpdate && selectedItem?.status !== 'archived' && (
         <MenuItem
           onClick={handleArchiveClick}
           disabled={isArchiving}


### PR DESCRIPTION
## Summary
- hide Archive menu item when a training plan or module is already archived

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`