### PR TITLE
Set default date range for manager dashboard

### DIFF
--- a/src/components/dashboard/manager/ManagerDashboard.tsx
+++ b/src/components/dashboard/manager/ManagerDashboard.tsx
@@ -1547,7 +1547,10 @@ const ManagerDashboard = () => {
   const [dropdownSearchQuery, setDropdownSearchQuery] = useState("");
   const [creatorSearchQuery, setCreatorSearchQuery] = useState("");
   const [teamSearchQuery, setTeamSearchQuery] = useState("");
-  const [dateRange, setDateRange] = useState<DateRange<Dayjs>>([null, null]);
+  const [dateRange, setDateRange] = useState<DateRange<Dayjs>>([
+    dayjs().subtract(6, "day"),
+    dayjs(),
+  ]);
   const [trainingEntityDateRange, setTrainingEntityDateRange] = useState<
     DateRange<Dayjs>
   >([null, null]);


### PR DESCRIPTION
## Summary
- set default manager dashboard date range to `Last 7 Days`

## Testing
- `npm run lint`
- `npm run build`
