### PR TITLE
Default date range shows "All Time"

### DIFF
--- a/src/components/common/DateSelector.tsx
+++ b/src/components/common/DateSelector.tsx
@@ -60,6 +60,9 @@ const DateSelector = ({
     if (dateRange[0] && dateRange[1]) {
       return `${dateRange[0].format("MMM D, YYYY")} - ${dateRange[1].format("MMM D, YYYY")}`;
     }
+    if (!dateRange[0] && !dateRange[1]) {
+      return "All Time";
+    }
     return "Select dates";
   };
 


### PR DESCRIPTION
## Summary
- show "All Time" by default in the DateSelector component

## Testing
- `npm run lint` *(fails: Invalid option '--ext' with new ESLint CLI)*