### PR TITLE
Fix module status filtering in ManageTrainingPlanPage

### DIFF
--- a/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
@@ -234,6 +234,10 @@ const ManageTrainingPlanPage = () => {
       params.createdBy = selectedCreator;
     }
 
+    if (selectedStatus !== 'All') {
+      params.status = [selectedStatus.toLowerCase()];
+    }
+
     return params;
   }, [
     page,


### PR DESCRIPTION
## Summary
- filter module results by status

## Testing
- `npx eslint .` *(fails: many lint errors)*
- `npm test` *(fails: missing script)*