### PR TITLE
Fix module status filter and enable actions on archived rows

### DIFF
--- a/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
@@ -192,11 +192,10 @@ const ManageTrainingPlanPage = () => {
       params.createdBy = selectedCreator;
     }
 
-    if (selectedStatus !== 'All') {
-      params.status = [selectedStatus.toLowerCase()];
-    }
-
-    if (selectedStatus !== 'All') {
+    if (selectedStatus === 'All') {
+      // Include both published and archived modules when "All" is selected
+      params.status = ['published', 'archived'];
+    } else {
       params.status = [selectedStatus.toLowerCase()];
     }
 
@@ -928,7 +927,6 @@ const ManageTrainingPlanPage = () => {
                           sx={{
                             cursor: isArchived ? 'default' : 'pointer',
                             opacity: isArchived ? 0.6 : 1,
-                            pointerEvents: isArchived ? 'none' : 'auto',
                             '&:hover': {
                               bgcolor: isArchived ? 'transparent' : 'action.hover',
                             },


### PR DESCRIPTION
## Summary
- include archived modules when `All` status selected
- allow actions menu on archived items

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*