### PR TITLE
Implement authentic blur mask

### DIFF
--- a/src/components/dashboard/trainee/manage/generate/ImageHotspot.tsx
+++ b/src/components/dashboard/trainee/manage/generate/ImageHotspot.tsx
@@ -29,6 +29,7 @@ import {
   CircularProgress,
   Tooltip,
 } from "@mui/material";
+import { withAlpha } from "../../../../../utils/color";
 import {
   Close as CloseIcon,
   Add as AddIcon,
@@ -1811,7 +1812,12 @@ const ImageHotspot: React.FC<ImageHotspotProps> = ({
             width: `${renderedCoords.width}px`,
             height: `${renderedCoords.height}px`,
             border: "2px solid #00AB55 ",
-            backgroundColor: masking.settings?.color,
+            backgroundColor: masking.settings?.blur_mask
+              ? withAlpha(
+                  masking.settings?.color || "rgba(0,0,0,1)",
+                  0.4,
+                )
+              : masking.settings?.color,
             cursor: "pointer",
             filter: "none",
             backdropFilter: masking.settings?.blur_mask ? "blur(2px)" : "none",

--- a/src/components/dashboard/trainee/manage/generate/VisualAudioPreview.tsx
+++ b/src/components/dashboard/trainee/manage/generate/VisualAudioPreview.tsx
@@ -16,6 +16,7 @@ import {
   Select,
   CircularProgress,
 } from "@mui/material";
+import { withAlpha } from "../../../../../utils/color";
 import {
   PlayArrow,
   Pause,
@@ -1385,7 +1386,12 @@ const VisualAudioPreview: React.FC<VisualAudioPreviewProps> = ({
                             ? `0 0 12px 3px ${item.content.settings?.color}`
                             : "none",
                           borderRadius: "4px",
-                          backgroundColor: item.content.settings?.color,
+                          backgroundColor: item.content.settings?.blur_mask
+                            ? withAlpha(
+                                item.content.settings?.color || "rgba(0,0,0,1)",
+                                0.4,
+                              )
+                            : item.content.settings?.color,
                           transition: "box-shadow 0.3s",
                           zIndex: 10,
                           filter: "none",

--- a/src/components/dashboard/trainee/manage/generate/VisualChatPreview.tsx
+++ b/src/components/dashboard/trainee/manage/generate/VisualChatPreview.tsx
@@ -17,6 +17,7 @@ import {
   CircularProgress,
   InputAdornment,
 } from "@mui/material";
+import { withAlpha } from "../../../../../utils/color";
 import {
   PlayArrow,
   Pause,
@@ -1338,7 +1339,12 @@ const VisualChatPreview: React.FC<VisualChatPreviewProps> = ({
                             ? `0 0 12px 3px ${item.content.settings?.color}`
                             : "none",
                           borderRadius: "4px",
-                          backgroundColor: item.content.settings?.color,
+                          backgroundColor: item.content.settings?.blur_mask
+                            ? withAlpha(
+                                item.content.settings?.color || "rgba(0,0,0,1)",
+                                0.4,
+                              )
+                            : item.content.settings?.color,
                           transition: "box-shadow 0.3s",
                           zIndex: 10,
                           filter: "none",

--- a/src/components/dashboard/trainee/manage/generate/VisualPreview.tsx
+++ b/src/components/dashboard/trainee/manage/generate/VisualPreview.tsx
@@ -15,6 +15,7 @@ import {
   CircularProgress,
   IconButton,
 } from "@mui/material";
+import { withAlpha } from "../../../../../utils/color";
 import {
   PlayArrow,
   Pause,
@@ -1170,7 +1171,12 @@ const VisualPreview: React.FC<VisualPreviewProps> = ({
                             ? `0 0 12px 3px ${item.content.settings?.color}`
                             : "none",
                           borderRadius: "4px",
-                          backgroundColor: item.content.settings?.color,
+                          backgroundColor: item.content.settings?.blur_mask
+                            ? withAlpha(
+                                item.content.settings?.color || "rgba(0,0,0,1)",
+                                0.4,
+                              )
+                            : item.content.settings?.color,
                           transition: "box-shadow 0.3s",
                           zIndex: 10,
                           filter: "none",

--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -18,6 +18,7 @@ import {
   CircularProgress,
   SvgIcon,
 } from "@mui/material";
+import { withAlpha } from "../../../../utils/color";
 import {
   PlayArrow as PlayArrowIcon,
   SmartToy as SmartToyIcon,
@@ -2882,7 +2883,12 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
                                     ? `0 0 12px 3px ${item.content.settings?.color}`
                                     : "none",
                                   borderRadius: "4px",
-                                  backgroundColor: item.content.settings?.color,
+                                  backgroundColor: item.content.settings?.blur_mask
+                                    ? withAlpha(
+                                        item.content.settings?.color || "rgba(0,0,0,1)",
+                                        0.4,
+                                      )
+                                    : item.content.settings?.color,
                                   transition: "box-shadow 0.3s",
                                   zIndex: 10,
                                   filter: "none",

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -19,6 +19,7 @@ import {
   Chip,
   SvgIcon,
 } from "@mui/material";
+import { withAlpha } from "../../../../utils/color";
 import {
   PlayArrow,
   Pause,
@@ -2115,7 +2116,12 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
                                     ? `0 0 12px 3px ${item.content.settings?.color}`
                                     : "none",
                                   borderRadius: "4px",
-                                  backgroundColor: item.content.settings?.color,
+                                  backgroundColor: item.content.settings?.blur_mask
+                                    ? withAlpha(
+                                        item.content.settings?.color || "rgba(0,0,0,1)",
+                                        0.4,
+                                      )
+                                    : item.content.settings?.color,
                                   transition: "box-shadow 0.3s",
                                   zIndex: 10,
                                   filter: "none",

--- a/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
@@ -18,6 +18,7 @@ import {
   Chip,
   SvgIcon,
 } from "@mui/material";
+import { withAlpha } from "../../../../utils/color";
 import {
   PlayArrow,
   Pause,
@@ -1928,7 +1929,12 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
                                     ? `0 0 12px 3px ${item.content.settings?.color}`
                                     : "none",
                                   borderRadius: "4px",
-                                  backgroundColor: item.content.settings?.color,
+                                  backgroundColor: item.content.settings?.blur_mask
+                                    ? withAlpha(
+                                        item.content.settings?.color || "rgba(0,0,0,1)",
+                                        0.4,
+                                      )
+                                    : item.content.settings?.color,
                                   transition: "box-shadow 0.3s",
                                   zIndex: 10,
                                   filter: "none",

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,17 @@
+export function withAlpha(color: string, alpha: number): string {
+  if (!color) return color;
+  const rgbaMatch = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)/i);
+  if (rgbaMatch) {
+    const [, r, g, b] = rgbaMatch;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  const hexMatch = color.match(/^#([0-9a-fA-F]{6})$/);
+  if (hexMatch) {
+    const hex = hexMatch[1];
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  return color;
+}


### PR DESCRIPTION
## Summary
- add util to apply alpha channel to color
- use the util for masking blur effect so the image behind is visible
- update visual preview and simulation pages to use new blur style

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`