### PR TITLE
Add global error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Layout from "./components/layout/Layout";
 import Unauthorized from "./components/Unauthorized";
 import { NotificationProvider } from './context/NotificationContext';
 import ErrorListener from './components/common/ErrorListener';
+import ErrorBoundary from './components/common/ErrorBoundary';
 
 // Lazy load components
 const TraineeDashboard = React.lazy(
@@ -137,7 +138,8 @@ const App: React.FC = () => {
             <ErrorListener />
             <WorkspaceHandler>
               <Layout>
-                <Suspense fallback={<LoadingSpinner />}>
+                <ErrorBoundary>
+                  <Suspense fallback={<LoadingSpinner />}>
                   <Routes>
                     {/* Public routes */}
                     <Route path="/unauthorized" element={<Unauthorized />} />
@@ -257,6 +259,7 @@ const App: React.FC = () => {
                     <Route path="*" element={<RootRedirect />} />
                   </Routes>
                 </Suspense>
+                </ErrorBoundary>
               </Layout>
             </WorkspaceHandler>
           </AuthProvider>

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,33 @@
+import React, { ErrorInfo } from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends React.Component<React.PropsWithChildren<{}>, ErrorBoundaryState> {
+  constructor(props: React.PropsWithChildren<{}>) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    if (/Failed to fetch dynamically imported module/.test(error.message)) {
+      window.location.reload();
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return null;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- add an `ErrorBoundary` component to handle runtime errors
- reload the page if dynamic imports fail
- wrap the main router with the error boundary

## Testing
- `npm run build`
