### PR TITLE
Exclude coaching tips from click scoring

### DIFF
--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -1261,9 +1261,9 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
       const container = imageContainerRef.current;
       if (!container) return;
 
-      // Skip tracking wrong clicks for dropdown and textbox hotspots
+      // Skip tracking wrong clicks for dropdown, textbox and coaching hotspots
       const hotspotType = currentItem.hotspotType || "button";
-      if (["dropdown", "textfield"].includes(hotspotType)) {
+      if (["dropdown", "textfield", "coaching"].includes(hotspotType)) {
         return;
       }
 

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -1364,6 +1364,12 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
       const container = imageContainerRef.current;
       if (!container) return;
 
+      // Skip tracking wrong clicks for dropdown, textfield and coaching hotspots
+      const hotspotType = currentItem.hotspotType || "button";
+      if (["dropdown", "textfield", "coaching"].includes(hotspotType)) {
+        return;
+      }
+
       // Get click position relative to the container
       const rect = container.getBoundingClientRect();
       const x = event.clientX - rect.left;


### PR DESCRIPTION
## Summary
- ignore coaching-tip hotspots when tracking wrong clicks in visual audio and chat simulations

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`