### PR TITLE
Add OverflowTooltip and fix Training Plan text

### DIFF
--- a/src/components/common/OverflowTooltip.tsx
+++ b/src/components/common/OverflowTooltip.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Tooltip } from '@mui/material';
+
+interface OverflowTooltipProps {
+  children: React.ReactNode;
+}
+
+const OverflowTooltip: React.FC<OverflowTooltipProps> = ({ children }) => {
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isOverflowed, setIsOverflowed] = useState(false);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (el) {
+      setIsOverflowed(el.scrollWidth > el.clientWidth);
+    }
+  }, [children]);
+
+  return (
+    <Tooltip title={children ?? ''} disableHoverListener={!isOverflowed} arrow>
+      <span
+        ref={textRef}
+        style={{
+          display: 'block',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {children}
+      </span>
+    </Tooltip>
+  );
+};
+
+export default OverflowTooltip;

--- a/src/components/dashboard/trainee/AssignSimulationsPage.tsx
+++ b/src/components/dashboard/trainee/AssignSimulationsPage.tsx
@@ -34,6 +34,7 @@ import DashboardContent from '../DashboardContent';
 import AssignTrainingPlanDialog from './AssignTrainingPlanDialog';
 import AssignModuleDialog from './AssignModuleDialog';
 import AssignSimulationsDialog from './AssignSimulationsDialog';
+import OverflowTooltip from '../../common/OverflowTooltip';
 import { 
   fetchAssignments, 
   type Assignment, 
@@ -64,6 +65,10 @@ const formatStatus = (status: string): string => {
 // Helper function to format type with capital first letter of all words
 const formatType = (type: string): string => {
   if (!type) return '';
+  const normalized = type.replace(/\s+/g, '').toLowerCase();
+  if (normalized === 'trainingplan') {
+    return 'Training Plan';
+  }
 
   // Split by common delimiters and capitalize each word
   return type
@@ -455,7 +460,7 @@ const AssignSimulationsPage = () => {
         }}
       >
         <TableCell sx={{ minWidth: 250 }}>
-          {row.name || 'Untitled Assignment'}
+          <OverflowTooltip>{row.name || 'Untitled Assignment'}</OverflowTooltip>
         </TableCell>
         <TableCell>
           <Tooltip title={formatType(row.type)} arrow>
@@ -523,7 +528,7 @@ const AssignSimulationsPage = () => {
         </TableCell>
         <TableCell>
           <Stack>
-            <Typography variant="body2" noWrap>{getUserName(row.last_modified_by)}</Typography>
+            <OverflowTooltip>{getUserName(row.last_modified_by)}</OverflowTooltip>
           </Stack>
         </TableCell>
         <TableCell sx={{ minWidth: 180 }}>
@@ -536,7 +541,7 @@ const AssignSimulationsPage = () => {
         </TableCell>
         <TableCell>
           <Stack>
-            <Typography variant="body2" noWrap>{getUserName(row.created_by)}</Typography>
+            <OverflowTooltip>{getUserName(row.created_by)}</OverflowTooltip>
           </Stack>
         </TableCell>
       </TableRow>

--- a/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
@@ -54,6 +54,7 @@ import { fetchUsersSummary, User, fetchUsersByIds } from "../../../../services/u
 import { useAuth } from "../../../../context/AuthContext";
 import { hasCreatePermission } from "../../../../utils/permissions";
 import { formatDateToTimeZone, formatTimeToTimeZone } from '../../../../utils/dateTime';
+import OverflowTooltip from '../../../common/OverflowTooltip';
 
 // Helper functions for date formatting with timezone
 const formatDate = (dateString: string, timeZone: string | null = null) => {
@@ -619,16 +620,10 @@ const ManageSimulationsPage = () => {
     return simulations.map((row, index) => (
       <TableRow key={index}>
         <TableCell sx={{ minWidth: 250 }}>
-          <Stack
-            direction="row"
-            spacing={1}
-            alignItems="center"
-          >
-            {row.sim_name}
+          <Stack direction="row" spacing={1} alignItems="center">
+            <OverflowTooltip>{row.sim_name}</OverflowTooltip>
             {row.islocked && (
-              <LockIcon
-                sx={{ fontSize: 16, color: "text.secondary" }}
-              />
+              <LockIcon sx={{ fontSize: 16, color: "text.secondary" }} />
             )}
           </Stack>
         </TableCell>
@@ -708,21 +703,22 @@ const ManageSimulationsPage = () => {
             >
               {row.tags &&
                 row.tags.map((tag, i) => (
-                  <Chip
-                    key={i}
-                    label={tag}
-                    size="small"
-                    sx={{
-                      bgcolor: "#F5F6FF",
-                      color: "#444CE7",
-                      maxWidth: "100%",
-                      "& .MuiChip-label": {
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      },
-                    }}
-                  />
+                  <Tooltip key={i} title={tag} arrow>
+                    <Chip
+                      label={tag}
+                      size="small"
+                      sx={{
+                        bgcolor: "#F5F6FF",
+                        color: "#444CE7",
+                        maxWidth: "100%",
+                        "& .MuiChip-label": {
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        },
+                      }}
+                    />
+                  </Tooltip>
                 ))}
             </Box>
           </Stack>
@@ -745,9 +741,9 @@ const ManageSimulationsPage = () => {
         </TableCell>
         <TableCell sx={{ minWidth: 150 }}>
           <Stack>
-            <Typography variant="body2" noWrap>
+            <OverflowTooltip>
               {getUserName(row.modified_by)}
-            </Typography>
+            </OverflowTooltip>
           </Stack>
         </TableCell>
         <TableCell sx={{ minWidth: 180 }}>
@@ -765,9 +761,9 @@ const ManageSimulationsPage = () => {
         </TableCell>
         <TableCell sx={{ minWidth: 150 }}>
           <Stack>
-            <Typography variant="body2" noWrap>
+            <OverflowTooltip>
               {getUserName(row.created_by)}
-            </Typography>
+            </OverflowTooltip>
           </Stack>
         </TableCell>
         <TableCell align="right" sx={{ width: 100 }}>

--- a/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
@@ -38,6 +38,7 @@ import TrainingPlanDetailsDialog from './TrainingPlanDetailsDialog';
 import ModuleDetailsDialog from './ModuleDetailsDialog';
 import EditTrainingPlanDialog from './EditTrainingPlanDialog';
 import EditModuleDialog from './EditModuleDialog';
+import OverflowTooltip from '../../../common/OverflowTooltip';
 import TrainingPlanActionsMenu from './TrainingPlanActionsMenu';
 import { useAuth } from '../../../../context/AuthContext';
 import { 
@@ -932,26 +933,29 @@ const ManageTrainingPlanPage = () => {
                             },
                           }}
                         >
-                          <TableCell sx={{ minWidth: 250 }}>{item.name}</TableCell>
+                          <TableCell sx={{ minWidth: 250 }}>
+                            <OverflowTooltip>{item.name}</OverflowTooltip>
+                          </TableCell>
                           <TableCell sx={{ width: 200 }}>
                             <Stack direction="row" spacing={1}>
                               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, maxWidth: 180 }}>
                                 {item.tags.map((tag, i) => (
-                                  <Chip
-                                    key={i}
-                                    label={tag}
-                                    size="small"
-                                    sx={{ 
-                                      bgcolor: '#F5F6FF', 
-                                      color: '#444CE7',
-                                      maxWidth: '100%',
-                                      '& .MuiChip-label': {
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap'
-                                      }
-                                    }}
-                                  />
+                                  <Tooltip key={i} title={tag} arrow>
+                                    <Chip
+                                      label={tag}
+                                      size="small"
+                                      sx={{
+                                        bgcolor: '#F5F6FF',
+                                        color: '#444CE7',
+                                        maxWidth: '100%',
+                                        '& .MuiChip-label': {
+                                          overflow: 'hidden',
+                                          textOverflow: 'ellipsis',
+                                          whiteSpace: 'nowrap'
+                                        }
+                                      }}
+                                    />
+                                  </Tooltip>
                                 ))}
                               </Box>
                             </Stack>
@@ -995,7 +999,9 @@ const ManageTrainingPlanPage = () => {
                           </TableCell>
                           <TableCell>
                             <Stack sx={{ minWidth: 150 }}>
-                              <Typography variant="body2" noWrap>{getUserName(item.created_by)}</Typography>
+                              <OverflowTooltip>
+                                {getUserName(item.created_by)}
+                              </OverflowTooltip>
                             </Stack>
                           </TableCell>
                           <TableCell>
@@ -1008,7 +1014,9 @@ const ManageTrainingPlanPage = () => {
                           </TableCell>
                           <TableCell>
                             <Stack sx={{ minWidth: 150 }}>
-                              <Typography variant="body2" noWrap>{getUserName(item.last_modified_by)}</Typography>
+                              <OverflowTooltip>
+                                {getUserName(item.last_modified_by)}
+                              </OverflowTooltip>
                             </Stack>
                           </TableCell>
                           <TableCell align="right" sx={{ width: 100 }}>


### PR DESCRIPTION
## Summary
- show tooltip when table text is truncated via new `OverflowTooltip` component
- use `OverflowTooltip` in ManageSimulations, ManageTrainingPlan and AssignSimulations pages
- tweak formatting of assignment type to display `Training Plan` correctly

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext')*