### PR TITLE
Fix final hotspot timeout calculation

### DIFF
--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -899,8 +899,13 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
         // Determine if this hotspot has timed out or should be considered clicked
         const hasTimeoutSetting = currentItem.settings?.timeoutDuration > 0;
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
         const isTimedOut =
-          timeoutActive || (hasTimeoutSetting && !currentItem.isClicked);
+          timeoutActive ||
+          (hasTimeoutSetting &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked));
 
         console.log(
           `Processing current hotspot ${currentItem.name} for end call, timed out: ${isTimedOut}`,
@@ -1991,8 +1996,13 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
         // Determine if this hotspot has timed out or should be considered clicked
         const hasTimeoutSetting = currentItem.settings?.timeoutDuration > 0;
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
         const isTimedOut =
-          timeoutActive || (hasTimeoutSetting && !currentItem.isClicked);
+          timeoutActive ||
+          (hasTimeoutSetting &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked));
 
         console.log(
           `Processing current hotspot ${currentItem.name} for end call, timed out: ${isTimedOut}`,

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -1237,8 +1237,13 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
 
         // Determine if this hotspot has timed out or should be considered clicked
         const hasTimeoutSetting = currentItem.settings?.timeoutDuration > 0;
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
         const isTimedOut =
-          timeoutActive || (hasTimeoutSetting && !currentItem.isClicked);
+          timeoutActive ||
+          (hasTimeoutSetting &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked));
 
         console.log(
           `Processing current hotspot ${currentItem.name} for end chat, timed out: ${isTimedOut}`,

--- a/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
@@ -1049,9 +1049,13 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
         );
 
         // Create the appropriate record based on the current state
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
         const isTimedOutHotspot =
           timeoutActive ||
-          (currentItem.settings?.timeoutDuration > 0 && !currentItem.isClicked);
+          (currentItem.settings?.timeoutDuration > 0 &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked));
 
         console.log(
           `Hotspot ${currentItem.name} timed out? ${isTimedOutHotspot}`,


### PR DESCRIPTION
## Summary
- ensure last hotspot is not marked timed out if a prior click was recorded across visual simulation variants

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: 555 errors)*