### PR TITLE
Fix last hotspot timeout by tracking clicks

### DIFF
--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -242,6 +242,7 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
     width: 0,
     height: 0,
   });
+  const lastClickedHotspotRef = useRef<string | null>(null);
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
@@ -899,8 +900,15 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
         // Determine if this hotspot has timed out or should be considered clicked
         const hasTimeoutSetting = currentItem.settings?.timeoutDuration > 0;
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
+        const wasClicked = lastClickedHotspotRef.current === currentItem.id;
         const isTimedOut =
-          timeoutActive || (hasTimeoutSetting && !currentItem.isClicked);
+          timeoutActive ||
+          (hasTimeoutSetting &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked) &&
+            !wasClicked);
 
         console.log(
           `Processing current hotspot ${currentItem.name} for end call, timed out: ${isTimedOut}`,
@@ -1354,6 +1362,10 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
     const shouldSetIsClicked = ["button", "highlight", "checkbox"].includes(
       hotspotType,
     );
+
+    if (shouldSetIsClicked) {
+      lastClickedHotspotRef.current = currentItem.id;
+    }
 
     // Create a clean clicked hotspot record
     const clickRecord = {
@@ -1991,8 +2003,15 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
         // Determine if this hotspot has timed out or should be considered clicked
         const hasTimeoutSetting = currentItem.settings?.timeoutDuration > 0;
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
+        const wasClicked = lastClickedHotspotRef.current === currentItem.id;
         const isTimedOut =
-          timeoutActive || (hasTimeoutSetting && !currentItem.isClicked);
+          timeoutActive ||
+          (hasTimeoutSetting &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked) &&
+            !wasClicked);
 
         console.log(
           `Processing current hotspot ${currentItem.name} for end call, timed out: ${isTimedOut}`,

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -353,6 +353,7 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
     width: 0,
     height: 0,
   });
+  const lastClickedHotspotRef = useRef<string | null>(null);
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
@@ -904,6 +905,10 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
       hotspotType,
     );
 
+    if (shouldSetIsClicked) {
+      lastClickedHotspotRef.current = currentItem.id;
+    }
+
     // Create a clean clicked hotspot record
     const clickRecord = {
       ...currentItem,
@@ -1237,8 +1242,15 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
 
         // Determine if this hotspot has timed out or should be considered clicked
         const hasTimeoutSetting = currentItem.settings?.timeoutDuration > 0;
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
+        const wasClicked = lastClickedHotspotRef.current === currentItem.id;
         const isTimedOut =
-          timeoutActive || (hasTimeoutSetting && !currentItem.isClicked);
+          timeoutActive ||
+          (hasTimeoutSetting &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked) &&
+            !wasClicked);
 
         console.log(
           `Processing current hotspot ${currentItem.name} for end chat, timed out: ${isTimedOut}`,

--- a/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
@@ -217,6 +217,7 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
     width: 0,
     height: 0,
   });
+  const lastClickedHotspotRef = useRef<string | null>(null);
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
@@ -745,6 +746,10 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
       hotspotType,
     );
 
+    if (shouldSetIsClicked) {
+      lastClickedHotspotRef.current = currentItem.id;
+    }
+
     // Update attempt data for this hotspot
     setAttemptSequenceData((prevData) => {
       const existingItemIndex = prevData.findIndex(
@@ -1049,9 +1054,15 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
         );
 
         // Create the appropriate record based on the current state
+        const existingRecord =
+          itemIndex >= 0 ? finalAttemptData[itemIndex] : null;
+        const wasClicked = lastClickedHotspotRef.current === currentItem.id;
         const isTimedOutHotspot =
           timeoutActive ||
-          (currentItem.settings?.timeoutDuration > 0 && !currentItem.isClicked);
+          (currentItem.settings?.timeoutDuration > 0 &&
+            !currentItem.isClicked &&
+            !(existingRecord && (existingRecord as any).isClicked) &&
+            !wasClicked);
 
         console.log(
           `Hotspot ${currentItem.name} timed out? ${isTimedOutHotspot}`,


### PR DESCRIPTION
## Summary
- track last clicked hotspot to ensure final hotspot isn't marked as timed out
- use this click reference in visual, visual-audio and visual-chat simulations

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: 624 problems)*