### PR TITLE
Fix settings state after publish

### DIFF
--- a/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
@@ -209,6 +209,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
   const mainContentRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [hasPublishedChanges, setHasPublishedChanges] = useState(false);
 
   // Add state for weightage validation
   const [isWeightageValid, setIsWeightageValid] = useState(true);
@@ -1011,6 +1012,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
       if (response.status === "success" || response.status === "published") {
         setPublishedSimId(simulationId);
         setShowPreview(true);
+        setHasPublishedChanges(true);
         if (onPublish) {
           onPublish();
         }
@@ -1523,6 +1525,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
               onSettingsChange={handleAdvancedSettingsChange}
               simulationType={simulationType}
               activeSection={activeSection}
+              hasPublishedChanges={hasPublishedChanges}
             />
 
             {/* Voice and Score settings with the prompt handler */}
@@ -1539,6 +1542,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
               enabledLevels={
                 settingsState.advancedSettings?.levels?.simulationLevels
               } // Pass enabled levels
+              hasPublishedChanges={hasPublishedChanges}
             />
           </Box>
         </Box>

--- a/src/components/dashboard/trainee/manage/generate/settingTab/VoiceScoreSetting.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/VoiceScoreSetting.tsx
@@ -57,6 +57,8 @@ interface VoiceScoreSettingProps {
     lvl2: boolean;
     lvl3: boolean;
   };
+  // When true, skip resetting form with API values after publish
+  hasPublishedChanges?: boolean;
 }
 
 interface ScoreMetricWeightage {
@@ -139,6 +141,7 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
   simulationType = "audio",
   onWeightageValidationChange,
   enabledLevels,
+  hasPublishedChanges,
 }) => {
   const [voices, setVoices] = useState<Voice[]>([]);
   const { user } = useAuth();
@@ -150,6 +153,9 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
   const [isProcessing, setIsProcessing] = useState(false);
   const [filteredVoices, setFilteredVoices] = useState<Voice[]>([]);
   const [weightageError, setWeightageError] = useState<string | null>(null);
+
+  // Track if we've already initialized the form with API data
+  const hasInitializedRef = useRef(false);
 
   // Calculate number of enabled levels
   const enabledLevelsCount = enabledLevels
@@ -241,7 +247,12 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
 
   // FIXED: Reset form when settings arrive from API (one-time initialization)
   useEffect(() => {
-    if (settings && settings.voice && settings.scoring) {
+    if (
+      settings &&
+      settings.voice &&
+      settings.scoring &&
+      (!hasInitializedRef.current || !hasPublishedChanges)
+    ) {
       console.log("Resetting VoiceAndScore form with API settings:", settings);
 
       reset({
@@ -292,6 +303,8 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
       if (settings.voice?.voiceId) {
         setSelectedVoice(settings.voice.voiceId);
       }
+
+      hasInitializedRef.current = true;
     }
   }, [settings, reset, hasScript, isAnyVisualType, enabledLevelsCount]);
 


### PR DESCRIPTION
## Summary
- track when settings are published
- skip resetting forms with API data once publish succeeds
- keep user settings when returning from preview

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*