### PR TITLE
Fix settings state after publish

### DIFF
--- a/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
@@ -194,6 +194,8 @@ const SettingTab: React.FC<SettingTabProps> = ({
     visualImages,
     setIsScriptLocked,
     assignedScriptMessageIds,
+    hasPublishedChanges,
+    setHasPublishedChanges,
   } = useSimulationWizard();
 
   // Use ID from URL params if available, fallback to prop
@@ -494,21 +496,23 @@ const SettingTab: React.FC<SettingTabProps> = ({
 
   // Only update settings when simulationData arrives (one-time)
   useEffect(() => {
-    if (simulationData) {
+    if (simulationData && !hasPublishedChanges) {
       console.log(
         "Received simulationData, updating settings:",
         simulationData,
       );
 
-      // Clear any cached settings to avoid conflicts
-      if (simulationId) {
+      // Clear any cached settings to avoid conflicts only when no published changes
+      if (simulationId && !hasPublishedChanges) {
         localStorage.removeItem(`simulation_settings_${simulationId}`);
       }
 
-      const newSettings = createSettingsFromData();
-      setSettingsState(newSettings);
+      if (!hasPublishedChanges) {
+        const newSettings = createSettingsFromData();
+        setSettingsState(newSettings);
+      }
     }
-  }, [simulationData]); // Only simulationData dependency
+  }, [simulationData, hasPublishedChanges]);
 
   // Save to localStorage after user changes (debounced)
   useEffect(() => {
@@ -1011,6 +1015,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
       if (response.status === "success" || response.status === "published") {
         setPublishedSimId(simulationId);
         setShowPreview(true);
+        setHasPublishedChanges(true);
         if (onPublish) {
           onPublish();
         }
@@ -1523,6 +1528,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
               onSettingsChange={handleAdvancedSettingsChange}
               simulationType={simulationType}
               activeSection={activeSection}
+              hasPublishedChanges={hasPublishedChanges}
             />
 
             {/* Voice and Score settings with the prompt handler */}
@@ -1539,6 +1545,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
               enabledLevels={
                 settingsState.advancedSettings?.levels?.simulationLevels
               } // Pass enabled levels
+              hasPublishedChanges={hasPublishedChanges}
             />
           </Box>
         </Box>

--- a/src/components/dashboard/trainee/manage/generate/settingTab/VoiceScoreSetting.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/VoiceScoreSetting.tsx
@@ -57,6 +57,8 @@ interface VoiceScoreSettingProps {
     lvl2: boolean;
     lvl3: boolean;
   };
+  // When true, skip resetting form with API values after publish
+  hasPublishedChanges?: boolean;
 }
 
 interface ScoreMetricWeightage {
@@ -139,6 +141,7 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
   simulationType = "audio",
   onWeightageValidationChange,
   enabledLevels,
+  hasPublishedChanges,
 }) => {
   const [voices, setVoices] = useState<Voice[]>([]);
   const { user } = useAuth();
@@ -150,6 +153,9 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
   const [isProcessing, setIsProcessing] = useState(false);
   const [filteredVoices, setFilteredVoices] = useState<Voice[]>([]);
   const [weightageError, setWeightageError] = useState<string | null>(null);
+
+  // Track if we've already initialized the form with API data
+  const hasInitializedRef = useRef(false);
 
   // Calculate number of enabled levels
   const enabledLevelsCount = enabledLevels
@@ -241,7 +247,12 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
 
   // FIXED: Reset form when settings arrive from API (one-time initialization)
   useEffect(() => {
-    if (settings && settings.voice && settings.scoring) {
+    if (
+      settings &&
+      settings.voice &&
+      settings.scoring &&
+      (!hasInitializedRef.current || !hasPublishedChanges)
+    ) {
       console.log("Resetting VoiceAndScore form with API settings:", settings);
 
       reset({
@@ -292,6 +303,8 @@ const VoiceAndScoreSettings: React.FC<VoiceScoreSettingProps> = ({
       if (settings.voice?.voiceId) {
         setSelectedVoice(settings.voice.voiceId);
       }
+
+      hasInitializedRef.current = true;
     }
   }, [settings, reset, hasScript, isAnyVisualType, enabledLevelsCount]);
 

--- a/src/context/SimulationWizardContext.tsx
+++ b/src/context/SimulationWizardContext.tsx
@@ -115,6 +115,10 @@ interface SimulationWizardContextType {
   isPublished: boolean;
   setIsPublished: (published: boolean) => void;
 
+  // Track if the user has published changes during this session
+  hasPublishedChanges: boolean;
+  setHasPublishedChanges: (published: boolean) => void;
+
   // Track which script message IDs are assigned to visuals
   assignedScriptMessageIds: Set<string>;
   setAssignedScriptMessageIds: (ids: Set<string>) => void;
@@ -191,6 +195,7 @@ export const SimulationWizardProvider: React.FC<{
     prompt: string;
   } | null>(null);
   const [isPublished, setIsPublished] = useState(false);
+  const [hasPublishedChanges, setHasPublishedChanges] = useState(false);
 
   // FIXED: Update settings while preserving ALL existing values
   const updateSettings = (newSettings: Partial<SimulationSettings>) => {
@@ -233,6 +238,8 @@ export const SimulationWizardProvider: React.FC<{
         setSimulationResponse,
         isPublished,
         setIsPublished,
+        hasPublishedChanges,
+        setHasPublishedChanges,
         assignedScriptMessageIds,
         setAssignedScriptMessageIds,
       }}


### PR DESCRIPTION
## Summary
- persist published state in SimulationWizard context
- avoid reloading API settings when returning to Settings tab

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*