### PR TITLE
Switch trainee table to backend pagination

### DIFF
--- a/src/components/dashboard/trainee/TraineeDashboard.tsx
+++ b/src/components/dashboard/trainee/TraineeDashboard.tsx
@@ -19,8 +19,6 @@ const HeaderChip = styled(Chip)(({ theme }) => ({
 const TraineeDashboard = () => {
   const { user } = useAuth();
   const [trainingData, setTrainingData] = useState<TrainingData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   const totalSimulationsCount =
     (trainingData?.training_plans?.reduce(
@@ -37,15 +35,10 @@ const TraineeDashboard = () => {
     const loadTrainingData = async () => {
       if (user?.id) {
         try {
-          setIsLoading(true);
-          setError(null);
           const data = await fetchTrainingData(user.id);
           setTrainingData(data);
         } catch (error) {
           console.error('Error loading training data:', error);
-          setError('Failed to load training data');
-        } finally {
-          setIsLoading(false);
         }
       }
     };
@@ -70,13 +63,7 @@ const TraineeDashboard = () => {
                   <HeaderChip label={`${totalSimulationsCount} Simulations`} size="small" />
                 </Stack>
               </Stack>
-              <TrainingPlanTable
-                trainingPlans={trainingData.training_plans || []}
-                modules={trainingData.modules || []}
-                simulations={trainingData.simulations || []}
-                isLoading={isLoading}
-                error={error}
-              />
+              <TrainingPlanTable />
             </>
           )}
         </Stack>

--- a/src/components/dashboard/trainee/TrainingItemsTable.tsx
+++ b/src/components/dashboard/trainee/TrainingItemsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Stack,
@@ -38,6 +38,10 @@ import timezone from "dayjs/plugin/timezone";
 import type { TrainingPlan, Module, Simulation } from "../../../types/training";
 import { useAuth } from "../../../context/AuthContext";
 import { buildPathWithWorkspace } from "../../../utils/navigation";
+import {
+  fetchTrainingItems,
+  type TrainingItemsPaginationParams,
+} from "../../../services/training";
 import DateSelector from "../../common/DateSelector";
 
 // Extend dayjs with plugins
@@ -45,11 +49,6 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 interface TrainingItemsTableProps {
-  trainingPlans?: TrainingPlan[];
-  modules?: Module[];
-  simulations?: Simulation[];
-  isLoading?: boolean;
-  error?: string | null;
   showTrainingPlans?: boolean; // Control whether to show training plans section
 }
 
@@ -67,15 +66,10 @@ const SectionHeader = styled(Typography)(({ theme }) => ({
 }));
 
 const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
-  trainingPlans = [],
-  modules = [],
-  simulations = [],
-  isLoading = false,
-  error = null,
   showTrainingPlans = true,
 }) => {
   const navigate = useNavigate();
-  const { currentWorkspaceId, currentTimeZone } = useAuth();
+  const { user, currentWorkspaceId, currentTimeZone } = useAuth();
   const [rowsPerPage, setRowsPerPage] = useState("5");
   const [currentPage, setCurrentPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
@@ -84,6 +78,13 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
   const [expandedModules, setExpandedModules] = useState<{
     [key: string]: boolean;
   }>({});
+  const [trainingPlans, setTrainingPlans] = useState<TrainingPlan[]>([]);
+  const [modules, setModules] = useState<Module[]>([]);
+  const [simulations, setSimulations] = useState<Simulation[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Format status labels to proper capitalization
   const formatStatusLabel = (status: string) => {
@@ -174,20 +175,65 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
     setCurrentPage(1);
   };
 
+  const loadTrainingItems = useCallback(async () => {
+    const params: TrainingItemsPaginationParams = {
+      page: currentPage,
+      pagesize: parseInt(rowsPerPage),
+    };
+
+    if (searchQuery.trim()) {
+      params.search = searchQuery.trim();
+    }
+    if (statusFilter !== "all") {
+      params.status = statusFilter;
+    }
+    if (dateRange[0]) {
+      params.startDate = dateRange[0].format("YYYY-MM-DD");
+    }
+    if (dateRange[1]) {
+      params.endDate = dateRange[1].format("YYYY-MM-DD");
+    }
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const data = await fetchTrainingItems(user?.id || "user123", params);
+      setTrainingPlans(data.training_plans || []);
+      setModules(data.modules || []);
+      setSimulations(data.simulations || []);
+      if (data.pagination) {
+        setTotalPages(data.pagination.total_pages);
+        setTotalCount(data.pagination.total_count);
+      }
+    } catch (err) {
+      console.error("Error loading training items:", err);
+      setError("Failed to load items");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    currentPage,
+    rowsPerPage,
+    searchQuery,
+    statusFilter,
+    dateRange,
+    currentWorkspaceId,
+  ]);
+
+  useEffect(() => {
+    loadTrainingItems();
+  }, [loadTrainingItems]);
+
   const isDateInRange = (dateStr: string | null) => {
     if (!dateStr) return true;
     if (!dateRange[0] && !dateRange[1]) return true;
 
-    // Parse the backend date (assumed to be in UTC)
     const backendDate = dayjs.utc(dateStr);
 
-    // Convert selected date range to UTC for comparison
-    // The selected dates are in the user's timezone, so we need to convert them
     let startDateUTC = null;
     let endDateUTC = null;
 
     if (dateRange[0]) {
-      // Convert start of day in user's timezone to UTC
       startDateUTC = currentTimeZone
         ? dayjs
             .tz(dateRange[0].format("YYYY-MM-DD"), currentTimeZone)
@@ -197,7 +243,6 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
     }
 
     if (dateRange[1]) {
-      // Convert end of day in user's timezone to UTC
       endDateUTC = currentTimeZone
         ? dayjs
             .tz(dateRange[1].format("YYYY-MM-DD"), currentTimeZone)
@@ -206,7 +251,6 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
         : dateRange[1].utc().endOf("day");
     }
 
-    // Compare UTC dates
     if (startDateUTC && endDateUTC) {
       return (
         backendDate.isAfter(startDateUTC) && backendDate.isBefore(endDateUTC)
@@ -220,106 +264,9 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
     return true;
   };
 
-  // Filter items based on search query, status, and date range
-  const filteredTrainingPlans = showTrainingPlans
-    ? trainingPlans.filter((plan) => {
-        if (
-          searchQuery &&
-          !plan.name.toLowerCase().includes(searchQuery.trim().toLowerCase())
-        ) {
-          return false;
-        }
-        if (statusFilter !== "all" && plan.status !== statusFilter) {
-          return false;
-        }
-        if (!isDateInRange(plan.due_date)) {
-          return false;
-        }
-        return true;
-      })
-    : [];
-
-  const filteredModules = modules.filter((module) => {
-    if (
-      searchQuery &&
-      !module.name.toLowerCase().includes(searchQuery.trim().toLowerCase())
-    ) {
-      return false;
-    }
-    if (statusFilter !== "all" && module.status !== statusFilter) {
-      return false;
-    }
-    if (!isDateInRange(module.due_date)) {
-      return false;
-    }
-    return true;
-  });
-
-  const filteredSimulations = simulations.filter((sim) => {
-    if (
-      searchQuery &&
-      !sim.name.toLowerCase().includes(searchQuery.trim().toLowerCase())
-    ) {
-      return false;
-    }
-    if (statusFilter !== "all" && sim.status !== statusFilter) {
-      return false;
-    }
-    if (!isDateInRange(sim.dueDate || sim.due_date)) {
-      return false;
-    }
-    return true;
-  });
-
-  // Calculate total filtered items
-  const totalFilteredItems =
-    filteredTrainingPlans.length +
-    filteredModules.length +
-    filteredSimulations.length;
-
-  // Calculate pagination
-  const pageSize = parseInt(rowsPerPage);
-  const startIndex = (currentPage - 1) * pageSize;
-  const endIndex = startIndex + pageSize;
-
-  // Get paginated items
-  const paginatedTrainingPlans = filteredTrainingPlans.slice(
-    startIndex,
-    endIndex,
-  );
-  const paginatedModules = filteredModules.slice(
-    Math.max(0, startIndex - filteredTrainingPlans.length),
-    Math.max(0, endIndex - filteredTrainingPlans.length),
-  );
-  const paginatedSimulations = filteredSimulations.slice(
-    Math.max(
-      0,
-      startIndex - filteredTrainingPlans.length - filteredModules.length,
-    ),
-    Math.max(
-      0,
-      endIndex - filteredTrainingPlans.length - filteredModules.length,
-    ),
-  );
-
-  // Ensure we don't exceed page size across all categories
-  let remainingItems = pageSize;
-  const displayedTrainingPlans = showTrainingPlans
-    ? paginatedTrainingPlans.slice(0, remainingItems)
-    : [];
-  if (showTrainingPlans) {
-    remainingItems -= displayedTrainingPlans.length;
-  }
-
-  const displayedModules =
-    remainingItems > 0 ? paginatedModules.slice(0, remainingItems) : [];
-  remainingItems -= displayedModules.length;
-
-  const displayedSimulations =
-    remainingItems > 0 ? paginatedSimulations.slice(0, remainingItems) : [];
-
-  // Calculate total pages
-  const totalPages = Math.max(1, Math.ceil(totalFilteredItems / pageSize));
+  const displayedTrainingPlans = showTrainingPlans ? trainingPlans : [];
+  const displayedModules = modules;
+  const displayedSimulations = simulations;
 
   const toggleModuleExpand = (moduleId: string, event: React.MouseEvent) => {
     event.stopPropagation();

--- a/src/components/dashboard/trainee/TrainingPlanPage.tsx
+++ b/src/components/dashboard/trainee/TrainingPlanPage.tsx
@@ -4,23 +4,23 @@ import DashboardContent from '../DashboardContent';
 import StatsGrid from './StatsGrid';
 import TrainingPlanTable from './TrainingPlanTable';
 import { useAuth } from '../../../context/AuthContext';
-import { fetchTrainingData } from '../../../services/training';
-import type { TrainingData } from '../../../types/training';
+import { fetchTrainingStats } from '../../../services/training';
+import type { TrainingStats } from '../../../types/training';
 
 const TrainingPlanPage = () => {
   const { user } = useAuth();
-  const [trainingData, setTrainingData] = useState<TrainingData | null>(null);
+  const [stats, setStats] = useState<TrainingStats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const loadTrainingData = async () => {
+    const loadStats = async () => {
       if (user?.id) {
         try {
           setIsLoading(true);
           setError(null);
-          const data = await fetchTrainingData(user.id);
-          setTrainingData(data);
+          const data = await fetchTrainingStats(user.id);
+          setStats(data.stats ?? data);
         } catch (error) {
           console.error('Error loading training data:', error);
           setError('Failed to load training data');
@@ -30,7 +30,7 @@ const TrainingPlanPage = () => {
       }
     };
 
-    loadTrainingData();
+    loadStats();
   }, [user?.id]);
 
   return (
@@ -45,16 +45,8 @@ const TrainingPlanPage = () => {
                 Monitor your score and progress on your assigned training plans
               </Typography>
             </Stack>
-            {trainingData?.stats && <StatsGrid stats={trainingData.stats} />}
-            {trainingData && (
-              <TrainingPlanTable 
-                trainingPlans={trainingData.training_plans || []}
-                modules={trainingData.modules || []}
-                simulations={trainingData.simulations || []}
-                isLoading={isLoading}
-                error={error}
-              />
-            )}
+            {stats && <StatsGrid stats={stats} />}
+            <TrainingPlanTable />
           </Stack>
         </Container>
       </DashboardContent>

--- a/src/components/dashboard/trainee/TrainingPlanTable.tsx
+++ b/src/components/dashboard/trainee/TrainingPlanTable.tsx
@@ -1,32 +1,8 @@
 import React from "react";
-import type { TrainingPlan, Module, Simulation } from "../../../types/training";
 import TrainingItemsTable from "./TrainingItemsTable";
 
-interface TrainingPlanTableProps {
-  trainingPlans: TrainingPlan[];
-  modules?: Module[];
-  simulations?: Simulation[];
-  isLoading?: boolean;
-  error?: string | null;
-}
-
-const TrainingPlanTable: React.FC<TrainingPlanTableProps> = ({
-  trainingPlans,
-  modules = [],
-  simulations = [],
-  isLoading = false,
-  error = null,
-}) => {
-  return (
-    <TrainingItemsTable
-      trainingPlans={trainingPlans}
-      modules={modules}
-      simulations={simulations}
-      isLoading={isLoading}
-      error={error}
-      showTrainingPlans={true}
-    />
-  );
+const TrainingPlanTable: React.FC = () => {
+  return <TrainingItemsTable showTrainingPlans={true} />;
 };
 
 export default TrainingPlanTable;

--- a/src/services/training.ts
+++ b/src/services/training.ts
@@ -1,5 +1,11 @@
 import apiClient from "./api/interceptors";
-import { TrainingData } from "../types/training";
+import type {
+  TrainingData,
+  TrainingStats,
+  TrainingPlan,
+  Module,
+  Simulation,
+} from "../types/training";
 
 export const fetchTrainingPlanDetails = async (
   userId: string,
@@ -24,6 +30,75 @@ export const fetchTrainingData = async (
     return response.data;
   } catch (error) {
     console.error("Error fetching training data:", error);
+    throw error;
+  }
+};
+
+export const fetchTrainingStats = async (
+  userId: string,
+): Promise<TrainingStats> => {
+  try {
+    const response = await apiClient.post('/fetch-assigned-stats', {
+      user_id: userId,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching training stats:', error);
+    throw error;
+  }
+};
+
+export interface TrainingItemsPaginationParams {
+  page: number;
+  pagesize: number;
+  search?: string;
+  status?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface TrainingItemsResponse {
+  training_plans: TrainingPlan[];
+  modules: Module[];
+  simulations: Simulation[];
+  pagination?: {
+    total_count: number;
+    page: number;
+    pagesize: number;
+    total_pages: number;
+  };
+}
+
+export const fetchTrainingItems = async (
+  userId: string,
+  params: TrainingItemsPaginationParams,
+): Promise<TrainingItemsResponse> => {
+  try {
+    const payload: Record<string, unknown> = { user_id: userId };
+
+    if (params) {
+      payload.pagination = {
+        page: params.page,
+        pagesize: params.pagesize,
+      };
+      if (params.search) {
+        payload.pagination.search = params.search;
+      }
+      if (params.status) {
+        payload.pagination.status = params.status;
+      }
+      if (params.startDate) {
+        payload.pagination.startDate = params.startDate;
+      }
+      if (params.endDate) {
+        payload.pagination.endDate = params.endDate;
+      }
+    }
+
+    const response = await apiClient.post("/fetch-assigned-plans", payload);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching training items:", error);
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- add `fetchTrainingStats` for stats-only API
- fetch stats grid separately in `TrainingPlanPage`
- clean up props in `TraineeDashboard`

## Testing
- `npx eslint .` *(fails: many existing lint errors)*
- `npm run build`
