### PR TITLE
Make entire new tag option clickable

### DIFF
--- a/src/components/dashboard/trainee/manage/CreateModuleDialog.tsx
+++ b/src/components/dashboard/trainee/manage/CreateModuleDialog.tsx
@@ -402,34 +402,40 @@ const CreateModuleDialog: React.FC<CreateModuleDialogProps> = ({
                       (tag) => tag.name === option,
                     );
 
-                    if (isNewOption) {
-                      return (
-                        <ListItem {...props} key={`create-${option}`}>
-                          <ListItemText
-                            primary={
-                              <Box
-                                sx={{ display: "flex", alignItems: "center" }}
-                              >
-                                <Typography>Create "{option}"</Typography>
-                                <Button
-                                  size="small"
-                                  startIcon={<AddIcon />}
-                                  variant="contained"
-                                  color="primary"
-                                  sx={{ ml: 2 }}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    handleCreateTag(option);
-                                  }}
-                                  disabled={isCreatingTag}
-                                >
-                                  {isCreatingTag ? "Creating..." : "Create"}
-                                </Button>
-                              </Box>
-                            }
-                          />
-                        </ListItem>
-                      );
+                      if (isNewOption) {
+                        return (
+                          <ListItem
+                            {...props}
+                            key={`create-${option}`}
+                            button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleCreateTag(option);
+                            }}
+                          >
+                            <ListItemText
+                              primary={
+                                <Box sx={{ display: "flex", alignItems: "center" }}>
+                                  <Typography>Create "{option}"</Typography>
+                                  <Button
+                                    size="small"
+                                    startIcon={<AddIcon />}
+                                    variant="contained"
+                                    color="primary"
+                                    sx={{ ml: 2 }}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleCreateTag(option);
+                                    }}
+                                    disabled={isCreatingTag}
+                                  >
+                                    {isCreatingTag ? "Creating..." : "Create"}
+                                  </Button>
+                                </Box>
+                              }
+                            />
+                          </ListItem>
+                        );
                     }
 
                     return (

--- a/src/components/dashboard/trainee/manage/CreateSimulationDialog.tsx
+++ b/src/components/dashboard/trainee/manage/CreateSimulationDialog.tsx
@@ -502,34 +502,40 @@ const CreateSimulationDialog: React.FC<CreateSimulationDialogProps> = ({
                         (tag) => tag.name === option,
                       );
 
-                      if (isNewOption) {
-                        return (
-                          <ListItem {...props} key={`create-${option}`}>
-                            <ListItemText
-                              primary={
-                                <Box
-                                  sx={{ display: "flex", alignItems: "center" }}
-                                >
-                                  <Typography>Create "{option}"</Typography>
-                                  <Button
-                                    size="small"
-                                    startIcon={<AddIcon />}
-                                    variant="contained"
-                                    color="primary"
-                                    sx={{ ml: 2 }}
-                                    onClick={(e) => {
-                                      e.stopPropagation();
-                                      handleCreateTag(option);
-                                    }}
-                                    disabled={isCreatingTag}
-                                  >
-                                    {isCreatingTag ? "Creating..." : "Create"}
-                                  </Button>
-                                </Box>
-                              }
-                            />
-                          </ListItem>
-                        );
+                        if (isNewOption) {
+                          return (
+                            <ListItem
+                              {...props}
+                              key={`create-${option}`}
+                              button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleCreateTag(option);
+                              }}
+                            >
+                              <ListItemText
+                                primary={
+                                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                                    <Typography>Create "{option}"</Typography>
+                                    <Button
+                                      size="small"
+                                      startIcon={<AddIcon />}
+                                      variant="contained"
+                                      color="primary"
+                                      sx={{ ml: 2 }}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleCreateTag(option);
+                                      }}
+                                      disabled={isCreatingTag}
+                                    >
+                                      {isCreatingTag ? "Creating..." : "Create"}
+                                    </Button>
+                                  </Box>
+                                }
+                              />
+                            </ListItem>
+                          );
                       }
 
                       return (

--- a/src/components/dashboard/trainee/manage/CreateTrainingPlanDialog.tsx
+++ b/src/components/dashboard/trainee/manage/CreateTrainingPlanDialog.tsx
@@ -437,12 +437,18 @@ const CreateTrainingPlanDialog: React.FC<CreateTrainingPlanDialogProps> = ({
 
                     if (isNewOption) {
                       return (
-                        <ListItem {...props} key={`create-${option}`}>
+                        <ListItem
+                          {...props}
+                          key={`create-${option}`}
+                          button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleCreateTag(option);
+                          }}
+                        >
                           <ListItemText
                             primary={
-                              <Box
-                                sx={{ display: "flex", alignItems: "center" }}
-                              >
+                              <Box sx={{ display: "flex", alignItems: "center" }}>
                                 <Typography>Create "{option}"</Typography>
                                 <Button
                                   size="small"


### PR DESCRIPTION
## Summary
- allow clicking anywhere on the "Create tag" option

## Testing
- `npm run lint` *(fails: Invalid option `--ext`)*