### PR TITLE
Remove reset filter buttons

### DIFF
--- a/src/components/dashboard/trainee/AssignSimulationsPage.tsx
+++ b/src/components/dashboard/trainee/AssignSimulationsPage.tsx
@@ -28,7 +28,6 @@ import {
 import {
   Search as SearchIcon,
   Clear as ClearIcon,
-  RestartAlt as ResetIcon,
 } from '@mui/icons-material';
 import DashboardContent from '../DashboardContent';
 import AssignTrainingPlanDialog from './AssignTrainingPlanDialog';
@@ -127,13 +126,6 @@ const AssignSimulationsPage = () => {
   // Check if user has create permission for assign-simulations
   const canAssignSimulations = hasCreatePermission('assign-simulations');
 
-  // Check if any filters are applied
-  const hasActiveFilters = useMemo(() => {
-    return (
-      searchQuery !== "" ||
-      selectedCreator !== "Created By"
-    );
-  }, [searchQuery, selectedCreator]);
 
   // Create a memoized pagination params object
   const paginationParams = useMemo<AssignmentPaginationParams>(() => {
@@ -380,13 +372,6 @@ const AssignSimulationsPage = () => {
     setSearchQuery("");
   };
 
-  // New function to reset all filters
-  const handleResetFilters = () => {
-    setSearchQuery("");
-    setSelectedCreator("Created By");
-    setCreatorSearchQuery("");
-    setPage(0);
-  };
 
   const getButtonText = () => {
     switch (currentTab) {
@@ -707,28 +692,6 @@ const AssignSimulationsPage = () => {
                 sx={{ width: 200 }}
               />
 
-              {/* Reset Filters Button */}
-              <Tooltip title="Reset all filters">
-                <span>
-                  <Button
-                    variant="outlined"
-                    startIcon={<ResetIcon />}
-                    onClick={handleResetFilters}
-                    disabled={!hasActiveFilters}
-                    sx={{
-                      borderColor: hasActiveFilters ? "#444CE7" : "#E0E0E0",
-                      color: hasActiveFilters ? "#444CE7" : "#A0A0A0",
-                      "&:hover": {
-                        borderColor: "#3538CD",
-                        bgcolor: "#F5F6FF",
-                      },
-                      borderRadius: 2,
-                      height: 40,
-                    }}
-                  >
-                  </Button>
-                </span>
-              </Tooltip>
             </Stack>
           </Stack>
 

--- a/src/components/dashboard/trainee/TrainingItemsTable.tsx
+++ b/src/components/dashboard/trainee/TrainingItemsTable.tsx
@@ -27,7 +27,6 @@ import {
   CalendarMonth as CalendarIcon,
   KeyboardArrowDown as ArrowDownIcon,
   Clear as ClearIcon,
-  RestartAlt as ResetIcon,
 } from "@mui/icons-material";
 import { DateRange } from "@mui/x-date-pickers-pro/models";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
@@ -96,15 +95,6 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
       .join(" ");
   };
 
-  // Check if any filters are applied
-  const hasActiveFilters = useMemo(() => {
-    return (
-      searchQuery !== "" ||
-      statusFilter !== "all" ||
-      dateRange[0] !== null ||
-      dateRange[1] !== null
-    );
-  }, [searchQuery, statusFilter, dateRange]);
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -166,13 +156,6 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
     console.log("Date range applied:", dateRange);
   };
 
-  // New function to reset all filters
-  const handleResetFilters = () => {
-    setSearchQuery("");
-    setDateRange([null, null]);
-    setStatusFilter("all");
-    setCurrentPage(1);
-  };
 
   const isDateInRange = (dateStr: string | null) => {
     if (!dateStr) return true;
@@ -412,27 +395,6 @@ const TrainingItemsTable: React.FC<TrainingItemsTableProps> = ({
               <MenuItem value="over_due">Overdue</MenuItem>
             </Select>
 
-            {/* Reset Filters Button */}
-            <Tooltip title="Reset all filters">
-              <span>
-                <Button
-                  variant="outlined"
-                  startIcon={<ResetIcon />}
-                  onClick={handleResetFilters}
-                  disabled={!hasActiveFilters}
-                  sx={{
-                    borderColor: hasActiveFilters ? "#444CE7" : "#E0E0E0",
-                    color: hasActiveFilters ? "#444CE7" : "#A0A0A0",
-                    "&:hover": {
-                      borderColor: "#3538CD",
-                      bgcolor: "#F5F6FF",
-                    },
-                    borderRadius: 2,
-                    height: 40,
-                  }}
-                ></Button>
-              </span>
-            </Tooltip>
           </Stack>
         </Paper>
 

--- a/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageSimulationsPage.tsx
@@ -34,7 +34,6 @@ import {
   LockOutlined as LockIcon,
   Clear as ClearIcon,
   FilterAlt as FilterIcon,
-  RestartAlt as ResetIcon,
 } from "@mui/icons-material";
 import DashboardContent from "../../DashboardContent";
 import ActionsMenu from "./ActionsMenu";
@@ -166,17 +165,6 @@ const ManageSimulationsPage = () => {
   // Check if user has create permission for manage-simulations
   const canCreateSimulation = hasCreatePermission("manage-simulations");
 
-  // Check if any filters are applied
-  const hasActiveFilters = useMemo(() => {
-    return (
-      searchQuery !== "" ||
-      selectedTags !== "All Tags" ||
-      selectedDepartment !== "All Departments" ||
-      selectedDivision !== "All Divisions" ||
-      selectedCreator !== "Created By" ||
-      currentTab !== "All"
-    );
-  }, [searchQuery, selectedTags, selectedDepartment, selectedDivision, selectedCreator, currentTab]);
 
   // Create a memoized pagination params object
   const paginationParams = useMemo<SimulationPaginationParams>(() => {
@@ -511,20 +499,6 @@ const ManageSimulationsPage = () => {
     setSearchQuery("");
   };
 
-  // New function to reset all filters
-  const handleResetFilters = () => {
-    setSearchQuery("");
-    setSelectedTags("All Tags");
-    setSelectedDepartment("All Departments");
-    setSelectedDivision("All Divisions");
-    setSelectedCreator("Created By");
-    setCreatorSearchQuery("");
-    setTagsSearchQuery("");
-    setDepartmentSearchQuery("");
-    setDivisionSearchQuery("");
-    setCurrentTab("All");
-    setPage(0);
-  };
 
   // Helper function to get user name from ID
   const getUserName = (userId: string): string => {
@@ -1051,28 +1025,6 @@ const ManageSimulationsPage = () => {
                 sx={{ width: 200 }}
               />
 
-              {/* Reset Filters Button */}
-              <Tooltip title="Reset all filters">
-                <span>
-                  <Button
-                    variant="outlined"
-                    startIcon={<ResetIcon />}
-                    onClick={handleResetFilters}
-                    disabled={!hasActiveFilters}
-                    sx={{
-                      borderColor: hasActiveFilters ? "#444CE7" : "#E0E0E0",
-                      color: hasActiveFilters ? "#444CE7" : "#A0A0A0",
-                      "&:hover": {
-                        borderColor: "#3538CD",
-                        bgcolor: "#F5F6FF",
-                      },
-                      borderRadius: 2,
-                      height: 40,
-                    }}
-                  >
-                  </Button>
-                </span>
-              </Tooltip>
             </Stack>
           </Stack>
 

--- a/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
+++ b/src/components/dashboard/trainee/manage/ManageTrainingPlanPage.tsx
@@ -29,7 +29,6 @@ import {
   MoreVert as MoreVertIcon,
   Search as SearchIcon,
   Clear as ClearIcon,
-  RestartAlt as ResetIcon,
 } from '@mui/icons-material';
 import DashboardContent from '../../DashboardContent';
 import CreateTrainingPlanDialog from './CreateTrainingPlanDialog';
@@ -142,15 +141,6 @@ const ManageTrainingPlanPage = () => {
   // Check if user has create permission for manage-training-plan
   const canCreateTrainingPlan = hasCreatePermission('manage-training-plan');
 
-  // Check if any filters are applied
-  const hasActiveFilters = useMemo(() => {
-    return (
-      searchQuery !== "" ||
-      selectedTags !== "All Tags" ||
-      selectedCreator !== "Created By" ||
-      selectedStatus !== "All"
-    );
-  }, [searchQuery, selectedTags, selectedCreator, selectedStatus]);
 
   // Helper function to check if an item is archived
   // Determine whether a training plan or module is archived. Some APIs may
@@ -476,16 +466,6 @@ const ManageTrainingPlanPage = () => {
     loadData();
   };
 
-  // New function to reset all filters
-  const handleResetFilters = () => {
-    setSearchQuery("");
-    setSelectedTags("All Tags");
-    setSelectedCreator("Created By");
-    setSelectedStatus("All");
-    setCreatorSearchQuery("");
-    setTagsSearchQuery("");
-    setPage(0);
-  };
 
   // Filter users based on search query
   const filteredUsers = useMemo(() => {
@@ -782,28 +762,6 @@ const ManageTrainingPlanPage = () => {
                 sx={{ width: 200 }}
               />
 
-              {/* Reset Filters Button */}
-              <Tooltip title="Reset all filters">
-                <span>
-                  <Button
-                    variant="outlined"
-                    startIcon={<ResetIcon />}
-                    onClick={handleResetFilters}
-                    disabled={!hasActiveFilters}
-                    sx={{
-                      borderColor: hasActiveFilters ? "#444CE7" : "#E0E0E0",
-                      color: hasActiveFilters ? "#444CE7" : "#A0A0A0",
-                      "&:hover": {
-                        borderColor: "#3538CD",
-                        bgcolor: "#F5F6FF",
-                      },
-                      borderRadius: 2,
-                      height: 40,
-                    }}
-                  >
-                  </Button>
-                </span>
-              </Tooltip>
             </Stack>
           </Stack>
 


### PR DESCRIPTION
## Summary
- remove Reset filters buttons from manage and assign pages
- drop unused ResetIcon imports and helpers

## Testing
- `npm run lint` *(fails: Invalid option '--ext' with ESLint 9)*