### PR TITLE
Fix manager dashboard score for simulations in progress

### DIFF
--- a/src/components/dashboard/manager/ManagerDashboard.tsx
+++ b/src/components/dashboard/manager/ManagerDashboard.tsx
@@ -1929,7 +1929,19 @@ const ManagerDashboard = () => {
         });
 
         setTrainingEntityPagination(data.pagination);
-        setTrainingEntityAttempts(data.training_entity);
+
+        const processedTrainingEntity = data.training_entity?.map((entity: any) => {
+          const processedTrainees = entity.trainees?.map((trainee: any) => ({
+            ...trainee,
+            avgScore:
+              trainee.status && trainee.status.toLowerCase() === "in_progress"
+                ? null
+                : trainee.avgScore,
+          }));
+          return { ...entity, trainees: processedTrainees };
+        });
+
+        setTrainingEntityAttempts(processedTrainingEntity);
         setError(null);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- process training entity data so trainees with in-progress simulations display NA

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*