### PR TITLE
Enable playing overview video in attempt page

### DIFF
--- a/src/services/video_upload.ts
+++ b/src/services/video_upload.ts
@@ -54,3 +54,14 @@ export const uploadOverviewVideo = async (
 
   return videoUrl;
 };
+
+/**
+ * Fetches a video by ID and returns it as a Blob.
+ * The backend expects the path to be `/videos/{video_id}`.
+ */
+export const getOverviewVideo = async (videoId: string): Promise<Blob> => {
+  const response = await apiClient.get(`/videos/${videoId}`, {
+    responseType: 'blob',
+  });
+  return response.data as Blob;
+};


### PR DESCRIPTION
## Summary
- add API helper to fetch overview video by ID
- load video blob in SimulationAttemptPage when trainee clicks Overview Video
- show fetched video in dialog for all simulation types

## Testing
- `npx eslint "src"` *(fails: many existing lint errors)*