### PR TITLE
Add video loading indicator

### DIFF
--- a/src/components/dashboard/trainee/SimulationAttemptPage.tsx
+++ b/src/components/dashboard/trainee/SimulationAttemptPage.tsx
@@ -88,6 +88,7 @@ const SimulationAttemptPage = () => {
   >(null);
   const [showStartPage, setShowStartPage] = useState(false);
   const [showOverviewVideo, setShowOverviewVideo] = useState(false);
+  const [isOverviewVideoLoading, setIsOverviewVideoLoading] = useState(false);
   const [overviewVideoUrl, setOverviewVideoUrl] = useState<string | null>(null);
   const [simulation, setSimulation] = useState<Simulation | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -381,6 +382,7 @@ const SimulationAttemptPage = () => {
   const handleOpenOverviewVideo = async () => {
     if (!simulation?.overview_video) return;
     try {
+      setIsOverviewVideoLoading(true);
       const videoId = simulation.overview_video.split('/').pop() ?? simulation.overview_video;
       const blob = await getOverviewVideo(videoId);
       const url = URL.createObjectURL(blob);
@@ -388,6 +390,8 @@ const SimulationAttemptPage = () => {
       setShowOverviewVideo(true);
     } catch (err) {
       console.error('Failed to load overview video', err);
+    } finally {
+      setIsOverviewVideoLoading(false);
     }
   };
 
@@ -588,12 +592,19 @@ const SimulationAttemptPage = () => {
                   <Stack direction="row" spacing={2}>
                     {simulation.overview_video && (
                       <Button
-                        startIcon={<PlayArrowIcon />}
+                        startIcon={
+                          isOverviewVideoLoading ? (
+                            <CircularProgress size={20} />
+                          ) : (
+                            <PlayArrowIcon />
+                          )
+                        }
                         variant="text"
                         sx={{ color: "#3A4170", bgcolor: "#F6F6FF", px: 2 }}
                         onClick={handleOpenOverviewVideo}
+                        disabled={isOverviewVideoLoading}
                       >
-                        Overview Video
+                        {isOverviewVideoLoading ? 'Loading...' : 'Overview Video'}
                       </Button>
                     )}
                   </Stack>


### PR DESCRIPTION
## Summary
- add isOverviewVideoLoading state
- show loading spinner on Overview Video button
- handle resetting loading state after fetching video

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*