### PR TITLE
Fix playback stats grid

### DIFF
--- a/src/components/dashboard/trainee/PlaybackPage.tsx
+++ b/src/components/dashboard/trainee/PlaybackPage.tsx
@@ -24,13 +24,13 @@ const PlaybackPage = () => {
         });
         const converted: TrainingStats = {
           simulation_completed: {
-            total_simulations: data.simultion_completion.total,
-            completed_simulations: data.simultion_completion.completed,
+            total_simulations: data.simulation_completion.total,
+            completed_simulations: data.simulation_completion.completed,
             percentage:
-              data.simultion_completion.total > 0
+              data.simulation_completion.total > 0
                 ? Math.round(
-                    (data.simultion_completion.completed /
-                      data.simultion_completion.total) *
+                    (data.simulation_completion.completed /
+                      data.simulation_completion.total) *
                       100,
                   )
                 : 0,

--- a/src/services/playback.ts
+++ b/src/services/playback.ts
@@ -57,7 +57,7 @@ export interface FetchPlaybackStatsPayload {
 }
 
 export interface FetchPlaybackStatsResponse {
-  simultion_completion: {
+  simulation_completion: {
     completed: number;
     total: number;
     total_modules: number;


### PR DESCRIPTION
## Summary
- correct playback stats API fields
- map `simulation_completion` stats correctly in playback page

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: Missing script)*