### PR TITLE
Handle feedback setting per level

### DIFF
--- a/src/components/dashboard/trainee/simulation/AudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/AudioSimulationPage.tsx
@@ -147,6 +147,12 @@ const AudioSimulationPage: React.FC<AudioSimulationPageProps> = ({
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
+  const showFeedbackButton =
+    (level === "Level 01" && simulation?.lvl1?.enablePostSimulationSurvey) ||
+    (level === "Level 02" && simulation?.lvl2?.enablePostSimulationSurvey) ||
+    (level === "Level 03" && simulation?.lvl3?.enablePostSimulationSurvey) ||
+    false;
+
   // Check if simulation was passed based on scores
   const isPassed = scores ? scores.FinalScore >= minPassingScore : false;
 
@@ -514,6 +520,7 @@ const AudioSimulationPage: React.FC<AudioSimulationPageProps> = ({
         onViewPlayback={handleViewPlayback}
         hasNextSimulation={hasNextSimulation}
         minPassingScore={minPassingScore}
+        showFeedbackButton={showFeedbackButton}
       />
 
       <Box sx={{ height: "100vh", bgcolor: "white", py: 0, px: 0 }}>

--- a/src/components/dashboard/trainee/simulation/ChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/ChatSimulationPage.tsx
@@ -101,6 +101,12 @@ const ChatSimulationPage: React.FC<ChatSimulationPageProps> = ({
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
+  const showFeedbackButton =
+    (level === "Level 01" && simulation?.lvl1?.enablePostSimulationSurvey) ||
+    (level === "Level 02" && simulation?.lvl2?.enablePostSimulationSurvey) ||
+    (level === "Level 03" && simulation?.lvl3?.enablePostSimulationSurvey) ||
+    false;
+
   // Check if simulation was passed based on scores
   const isPassed = scores ? scores.FinalScore >= minPassingScore : false;
 
@@ -317,6 +323,7 @@ const ChatSimulationPage: React.FC<ChatSimulationPageProps> = ({
         onViewPlayback={undefined} // Chat doesn't have playback
         hasNextSimulation={hasNextSimulation}
         minPassingScore={minPassingScore}
+        showFeedbackButton={showFeedbackButton}
       />
 
       {/* Only render the chat interface when completion screen is NOT showing */}

--- a/src/components/dashboard/trainee/simulation/SimulationCompletionScreen.tsx
+++ b/src/components/dashboard/trainee/simulation/SimulationCompletionScreen.tsx
@@ -36,6 +36,11 @@ interface SimulationCompletionScreenProps {
   onShareFeedback?: () => void;
   hasNextSimulation?: boolean;
   minPassingScore: number;
+  /**
+   * Whether to display the Share Feedback button. Defaults to true for
+   * backwards compatibility.
+   */
+  showFeedbackButton?: boolean;
 }
 
 const SimulationCompletionScreen: React.FC<SimulationCompletionScreenProps> = ({
@@ -56,6 +61,7 @@ const SimulationCompletionScreen: React.FC<SimulationCompletionScreenProps> = ({
   onViewPlayback,
   hasNextSimulation = false,
   minPassingScore,
+  showFeedbackButton = true,
 }) => {
   const { user } = useAuth();
   const { showNotification } = useNotification();
@@ -429,12 +435,14 @@ const SimulationCompletionScreen: React.FC<SimulationCompletionScreenProps> = ({
               >
                 View Playback
               </button>
-              <button
-                onClick={handleOpenFeedbackDialog}
-                className="py-3 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-bold"
-              >
-                Share Feedback
-              </button>
+              {showFeedbackButton && (
+                <button
+                  onClick={handleOpenFeedbackDialog}
+                  className="py-3 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-bold"
+                >
+                  Share Feedback
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -274,6 +274,9 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
 
   const levelSettings = getLevelSettings();
 
+  const showFeedbackButton =
+    levelSettings?.enablePostSimulationSurvey === true;
+
   // Function to check if a hotspot should be skipped based on settings
   const shouldSkipHotspot = () => {
     if (!currentItem || currentItem.type !== "hotspot" || !levelSettings)
@@ -2373,6 +2376,7 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
         onViewPlayback={handleViewPlayback}
         hasNextSimulation={hasNextSimulation}
         minPassingScore={minPassingScore}
+        showFeedbackButton={showFeedbackButton}
       />
 
       <Box

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -359,6 +359,12 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
+  const showFeedbackButton =
+    (level === "Level 01" && simulation?.lvl1?.enablePostSimulationSurvey) ||
+    (level === "Level 02" && simulation?.lvl2?.enablePostSimulationSurvey) ||
+    (level === "Level 03" && simulation?.lvl3?.enablePostSimulationSurvey) ||
+    false;
+
   // Check if simulation was passed based on scores
   const isPassed = scores ? scores.FinalScore >= minPassingScore : false;
 
@@ -1663,6 +1669,7 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
         onViewPlayback={handleViewPlayback}
         hasNextSimulation={hasNextSimulation}
         minPassingScore={minPassingScore}
+        showFeedbackButton={showFeedbackButton}
       />
 
       <Box

--- a/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
@@ -222,6 +222,12 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
 
   const minPassingScore = simulation?.minimum_passing_score || 85;
 
+  const showFeedbackButton =
+    (level === "Level 01" && simulation?.lvl1?.enablePostSimulationSurvey) ||
+    (level === "Level 02" && simulation?.lvl2?.enablePostSimulationSurvey) ||
+    (level === "Level 03" && simulation?.lvl3?.enablePostSimulationSurvey) ||
+    false;
+
   // Check if simulation was passed based on scores
   const isPassed = scores ? scores.FinalScore >= minPassingScore : false;
 
@@ -1382,6 +1388,7 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
         onViewPlayback={handleViewPlayback}
         hasNextSimulation={hasNextSimulation}
         minPassingScore={minPassingScore}
+        showFeedbackButton={showFeedbackButton}
       />
 
       <Box sx={{ height: "100%", bgcolor: "white", py: 0, px: 0 }}>


### PR DESCRIPTION
## Summary
- only show feedback button when the current level has post simulation surveys enabled

## Testing
- `npx eslint .` *(fails: Unexpected any)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683ace11e6188322add058d21c6bfa1a