### PR TITLE
Include simulation level in feedback submission

### DIFF
--- a/src/components/dashboard/trainee/simulation/SimulationCompletionScreen.tsx
+++ b/src/components/dashboard/trainee/simulation/SimulationCompletionScreen.tsx
@@ -108,6 +108,7 @@ const SimulationCompletionScreen: React.FC<SimulationCompletionScreenProps> = ({
       await submitFeedback({
         user_id: user.id,
         simulation_id: simulationId,
+        simulation_level: level,
         attempt_id: attemptId,
         feedback: data,
       });

--- a/src/services/feedback.ts
+++ b/src/services/feedback.ts
@@ -13,6 +13,8 @@ export interface FeedbackFormData {
 export interface SubmitFeedbackRequest {
   user_id: string;
   simulation_id: string;
+  /** The level of the simulation, e.g. "beginner" */
+  simulation_level: string;
   attempt_id: string;
   feedback: FeedbackFormData;
 }


### PR DESCRIPTION
## Summary
- update feedback request interface to include `simulation_level`
- send simulation level when submitting feedback

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_683bb924801883228b37173ca15eff08