### PR TITLE
Fix overview video persistence

### DIFF
--- a/src/components/dashboard/trainee/manage/generate/GenerateScript.tsx
+++ b/src/components/dashboard/trainee/manage/generate/GenerateScript.tsx
@@ -437,6 +437,7 @@ const GenerateScriptContent = () => {
               "Be polite and empathetic",
               "Provide accurate information",
             ],
+            overview_video: simulation.overview_video ?? "",
             voice_id: simulation.voice_id ?? "",
             language: simulation.language ?? "English",
             voice_speed: simulation.voice_speed ?? "Normal",

--- a/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
+++ b/src/components/dashboard/trainee/manage/generate/settingTab/SettingTab.tsx
@@ -783,9 +783,7 @@ const SettingTab: React.FC<SettingTabProps> = ({
       key_objectives: objectivesSettings.enabled
         ? processTextToArray(objectivesSettings.text)
         : [],
-      overview_video:
-        contextSettings?.overviewVideo?.url ||
-        "https://example.com/overview.mp4",
+      overview_video: contextSettings?.overviewVideo?.url || "",
       quick_tips: tipsSettings.enabled
         ? processTextToArray(tipsSettings.text)
         : [],


### PR DESCRIPTION
## Summary
- ensure overview video is stored when loading simulations

## Testing
- `npx eslint .` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_683bf39084c08322ad1c2a72c90d901e