### PR TITLE
Update playback fetch API call

### DIFF
--- a/src/components/dashboard/trainee/playback/PlaybackTable.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackTable.tsx
@@ -119,13 +119,40 @@ const PlaybackTable = () => {
         setIsLoading(true);
         setError(null);
 
-        const payload: FetchPlaybackRowDataPayload = { user_id: user.id };
+        const pagination: PlaybackRowPaginationParams = {
+          ...paginationParams,
+          search: searchQuery.trim() || undefined,
+        };
 
-        if (paginationParams) {
-          payload["pagination"] = paginationParams;
+        if (simTypeFilter !== "all") {
+          pagination.simType = simTypeFilter;
         }
 
-        // In a real implementation, we would fetch data from the API
+        if (levelFilter !== "all") {
+          pagination.level = levelFilter.startsWith("level")
+            ? levelFilter
+            : `level${levelFilter}`;
+        }
+
+        if (dateRange[0]) {
+          pagination.createdFrom = dateRange[0]
+            .utc()
+            .startOf("day")
+            .toISOString();
+        }
+
+        if (dateRange[1]) {
+          pagination.createdTo = dateRange[1]
+            .utc()
+            .endOf("day")
+            .toISOString();
+        }
+
+        const payload: FetchPlaybackRowDataPayload = {
+          user_id: user.id,
+          pagination,
+        };
+
         const data = await fetchPlaybackRowData(payload);
         setPlaybackData(data);
       } catch (error) {
@@ -139,7 +166,7 @@ const PlaybackTable = () => {
 
   useEffect(() => {
     loadPlaybackData();
-  }, [user?.id, paginationParams]);
+  }, [user?.id, paginationParams, simTypeFilter, levelFilter, dateRange]);
 
   return (
     <Stack spacing={2}>

--- a/src/services/playback.ts
+++ b/src/services/playback.ts
@@ -20,6 +20,8 @@ export interface AttemptsResponse {
   attemptType: string;
   estTime: number;
   attemptCount: number;
+  attemptNumber?: number;
+  latestAttemptDate?: string;
 }
 export interface FetchPlaybackRowDataResponse {
   attempts: AttemptsResponse[];
@@ -81,6 +83,11 @@ export interface PlaybackRowPaginationParams {
   pagesize: number;
   sortDir?: "asc" | "desc";
   search?: string;
+  simType?: string;
+  type?: string;
+  level?: string;
+  createdFrom?: string;
+  createdTo?: string;
 }
 
 // New interface for insights request


### PR DESCRIPTION
## Summary
- allow more filters for attempts API
- support pagination filters on PlaybackTable

## Testing
- `npm run build`
- `tsc -p tsconfig.json`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_683cca2132e48322b737e7eeda5ecc12