### PR TITLE
Add pagination metadata to playback attempts

### DIFF
--- a/src/components/dashboard/trainee/playback/PlaybackTable.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackTable.tsx
@@ -40,6 +40,8 @@ const PlaybackTable = () => {
     });
   const [playbackData, setPlaybackData] =
     useState<FetchPlaybackRowDataResponse | null>(null);
+  const [totalCount, setTotalCount] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [dateRange, setDateRange] = useState<DateRange<Dayjs>>([
@@ -153,6 +155,11 @@ const PlaybackTable = () => {
 
         const data = await fetchPlaybackRowData(payload);
         setPlaybackData(data);
+
+        if (data.pagination) {
+          setTotalCount(data.pagination.total_count);
+          setTotalPages(data.pagination.total_pages);
+        }
       } catch (error) {
         console.error("Error loading playback data:", error);
         setError("Failed to load playback data");
@@ -453,7 +460,7 @@ const PlaybackTable = () => {
 
       <TablePagination
         component="div"
-        count={filteredData.length}
+        count={totalCount}
         page={paginationParams.page - 1}
         onPageChange={(_: unknown, newPage: number) =>
           setPaginationParams((prevState) => ({

--- a/src/services/playback.ts
+++ b/src/services/playback.ts
@@ -23,9 +23,17 @@ export interface AttemptsResponse {
   attemptNumber?: number;
   latestAttemptDate?: string;
 }
+export interface PaginationMetadata {
+  total_count: number;
+  page: number;
+  pagesize: number;
+  total_pages: number;
+}
+
 export interface FetchPlaybackRowDataResponse {
   attempts: AttemptsResponse[];
   total_attempts: number;
+  pagination?: PaginationMetadata;
 }
 
 export interface FetchPlaybackByIdRowDataPayload {
@@ -110,7 +118,24 @@ export const fetchPlaybackRowData = async (
 ): Promise<FetchPlaybackRowDataResponse> => {
   try {
     const response = await apiClient.post("/attempts/fetch", payload);
-    return response.data;
+
+    return {
+      attempts: response.data.attempts || [],
+      total_attempts: response.data.total_attempts || 0,
+      pagination:
+        response.data.pagination ||
+        (payload.pagination
+          ? {
+              total_count: response.data.total_attempts || 0,
+              page: payload.pagination.page,
+              pagesize: payload.pagination.pagesize,
+              total_pages: Math.ceil(
+                (response.data.total_attempts || 0) /
+                  payload.pagination.pagesize,
+              ),
+            }
+          : undefined),
+    };
   } catch (error) {
     console.error("Error fetching manager dashboard aggregated data:", error);
     throw error;


### PR DESCRIPTION
## Summary
- include pagination metadata types for attempts fetch service
- parse pagination info in fetchPlaybackRowData
- store and use pagination totals in playback table

## Testing
- `npx eslint .` *(fails: Unexpected any type errors)*

------
https://chatgpt.com/codex/tasks/task_e_683cd662d0588322a16b19324fab822a