### PR TITLE
Send simulation level in start requests

### DIFF
--- a/src/components/dashboard/trainee/simulation/AudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/AudioSimulationPage.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../../../services/simulation_audio_attempts";
 import SimulationCompletionScreen from "./SimulationCompletionScreen";
 import { buildPathWithWorkspace } from "../../../../utils/navigation";
+import { mapLevelToCode } from "../../../../utils/simulation";
 
 interface Message {
   speaker: "customer" | "trainee";
@@ -346,6 +347,7 @@ const AudioSimulationPage: React.FC<AudioSimulationPageProps> = ({
         sim_id: simulationId,
         assignment_id: assignmentId,
         attempt_type: attemptType, // Pass the attemptType
+        simulation_level: mapLevelToCode(level),
       });
 
 

--- a/src/components/dashboard/trainee/simulation/ChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/ChatSimulationPage.tsx
@@ -27,6 +27,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../../../context/AuthContext"; // Update path as needed
 import { buildPathWithWorkspace } from "../../../../utils/navigation";
+import { mapLevelToCode } from "../../../../utils/simulation";
 import {
   startChatSimulation,
   sendChatMessage,
@@ -158,6 +159,7 @@ const ChatSimulationPage: React.FC<ChatSimulationPageProps> = ({
         simulationId,
         assignmentId,
         attemptType,
+        mapLevelToCode(level),
       );
 
 

--- a/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualAudioSimulationPage.tsx
@@ -51,6 +51,7 @@ import { textToSpeech } from "../../../../services/text_to_speech";
 import { AttemptInterface } from "../../../../types/attempts";
 import SimulationCompletionScreen from "./SimulationCompletionScreen";
 import { buildPathWithWorkspace } from "../../../../utils/navigation";
+import { mapLevelToCode } from "../../../../utils/simulation";
 
 // Utility interfaces for percentage-based coordinate system
 interface PercentageCoordinates {
@@ -1895,6 +1896,7 @@ const VisualAudioSimulationPage: React.FC<VisualAudioSimulationPageProps> = ({
         simulationId,
         assignmentId,
         attemptType, // Pass the attemptType
+        mapLevelToCode(level),
       );
 
 

--- a/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualChatSimulationPage.tsx
@@ -52,6 +52,7 @@ import {
 import { AttemptInterface } from "../../../../types/attempts";
 import SimulationCompletionScreen from "./SimulationCompletionScreen";
 import { buildPathWithWorkspace } from "../../../../utils/navigation";
+import { mapLevelToCode } from "../../../../utils/simulation";
 
 // Utility interfaces for percentage-based coordinate system
 interface PercentageCoordinates {
@@ -1298,6 +1299,7 @@ const VisualChatSimulationPage: React.FC<VisualChatSimulationPageProps> = ({
         simulationId,
         assignmentId,
         attemptType, // Pass the attemptType
+        mapLevelToCode(level),
       );
 
 

--- a/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
+++ b/src/components/dashboard/trainee/simulation/VisualSimulationPage.tsx
@@ -46,6 +46,7 @@ import {
 import { AttemptInterface } from "../../../../types/attempts";
 import SimulationCompletionScreen from "./SimulationCompletionScreen";
 import { buildPathWithWorkspace } from "../../../../utils/navigation";
+import { mapLevelToCode } from "../../../../utils/simulation";
 
 // Utility interfaces for percentage-based coordinate system
 interface PercentageCoordinates {
@@ -993,6 +994,7 @@ const VisualSimulationPage: React.FC<VisualSimulationPageProps> = ({
         simulationId,
         assignmentId,
         attemptType, // Pass the attemptType
+        mapLevelToCode(level),
       );
 
 

--- a/src/services/simulation_audio_attempts.ts
+++ b/src/services/simulation_audio_attempts.ts
@@ -8,6 +8,7 @@ export interface StartAudioSimulationRequest {
   sim_id: string;
   assignment_id: string;
   attempt_type: string; // "Test" or "Practice"
+  simulation_level: string;
   message?: string;
   usersimulationprogress_id?: string;
 }

--- a/src/services/simulation_chat_attempts.ts
+++ b/src/services/simulation_chat_attempts.ts
@@ -6,6 +6,7 @@ export interface ChatStartRequest {
   sim_id: string;
   assignment_id: string;
   attempt_type: string; // "Test" or "Practice"
+  simulation_level: string;
 }
 
 export interface ChatMessageRequest {
@@ -65,6 +66,7 @@ export const startChatSimulation = async (
   simId: string,
   assignmentId: string,
   attemptType: string,
+  simulationLevel: string,
 ): Promise<ChatResponse> => {
   try {
     const response = await apiClient.post<ChatResponse>(
@@ -74,6 +76,7 @@ export const startChatSimulation = async (
         sim_id: simId,
         assignment_id: assignmentId,
         attempt_type: attemptType,
+        simulation_level: simulationLevel,
       },
     );
 

--- a/src/services/simulation_visual_attempts.ts
+++ b/src/services/simulation_visual_attempts.ts
@@ -107,6 +107,7 @@ export interface StartVisualSimulationRequest {
   sim_id: string;
   assignment_id: string;
   attempt_type: string; // "Test" or "Practice"
+  simulation_level: string;
 }
 
 export interface EndVisualSimulationRequest {
@@ -163,6 +164,7 @@ export const startVisualSimulation = async (
   simulationId: string,
   assignmentId: string,
   attemptType: string,
+  simulationLevel: string,
 ): Promise<VisualSimulationResponse> => {
   try {
     const response = await apiClient.post<VisualSimulationResponse>(
@@ -172,6 +174,7 @@ export const startVisualSimulation = async (
         sim_id: simulationId,
         assignment_id: assignmentId,
         attempt_type: attemptType,
+        simulation_level: simulationLevel,
       },
     );
 

--- a/src/services/simulation_visual_audio_attempts.ts
+++ b/src/services/simulation_visual_audio_attempts.ts
@@ -116,6 +116,7 @@ export interface StartVisualAudioRequest {
   sim_id: string;
   assignment_id: string;
   attempt_type: string; // "Test" or "Practice"
+  simulation_level: string;
 }
 
 export interface StartVisualAudioResponse {
@@ -195,6 +196,7 @@ export const startVisualAudioAttempt = async (
   simulationId: string,
   assignmentId: string,
   attemptType: string,
+  simulationLevel: string,
 ): Promise<StartVisualAudioResponse> => {
   try {
     const response = await apiClient.post<StartVisualAudioResponse>(
@@ -204,6 +206,7 @@ export const startVisualAudioAttempt = async (
         sim_id: simulationId,
         assignment_id: assignmentId,
         attempt_type: attemptType,
+        simulation_level: simulationLevel,
       },
     );
 

--- a/src/services/simulation_visual_chat_attempts.ts
+++ b/src/services/simulation_visual_chat_attempts.ts
@@ -123,6 +123,7 @@ export interface StartVisualChatRequest {
   sim_id: string;
   assignment_id: string;
   attempt_type: string; // "Test" or "Practice"
+  simulation_level: string;
 }
 
 export interface StartVisualChatResponse {
@@ -171,6 +172,7 @@ export const startVisualChatAttempt = async (
   simulationId: string,
   assignmentId: string,
   attemptType: string,
+  simulationLevel: string,
 ): Promise<StartVisualChatResponse> => {
   try {
     const response = await apiClient.post<StartVisualChatResponse>(
@@ -180,6 +182,7 @@ export const startVisualChatAttempt = async (
         sim_id: simulationId,
         assignment_id: assignmentId,
         attempt_type: attemptType,
+        simulation_level: simulationLevel,
       },
     );
 

--- a/src/utils/simulation.ts
+++ b/src/utils/simulation.ts
@@ -1,0 +1,12 @@
+export const mapLevelToCode = (level: string): string => {
+  switch (level) {
+    case "Level 01":
+      return "lvl1";
+    case "Level 02":
+      return "lvl2";
+    case "Level 03":
+      return "lvl3";
+    default:
+      return level.toLowerCase();
+  }
+};


### PR DESCRIPTION
## Summary
- add helper to map selected levels to API codes
- extend request models for starting simulations with `simulation_level`
- pass level parameter in start requests from trainee pages

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683d7356e5bc83228e88ffdeb07c55db