### PR TITLE
Remove vertical scrollbar in playback table

### DIFF
--- a/src/components/dashboard/trainee/playback/PlaybackTable.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackTable.tsx
@@ -563,6 +563,8 @@ const PlaybackTable = () => {
         }}
       >
         <DataGridPremium
+          autoHeight
+          rowHeight={68}
           rows={filteredData}
           columns={columns}
           getRowId={(row) => row.id}
@@ -681,7 +683,7 @@ const PlaybackTable = () => {
               height: '8px',
             },
             '& .MuiDataGrid-scrollbar--vertical': {
-              width: '8px',
+              display: 'none',
             },
           }}
         />


### PR DESCRIPTION
## Summary
- adjust playback table row height so all rows display when vertical scroll is hidden

## Testing
- `npm run lint` *(fails: Invalid option --ext)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683d8f4c16c8832290d4538673ff0d79