### PR TITLE
Fix attempt type filter case

### DIFF
--- a/src/components/dashboard/trainee/playback/PlaybackTable.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackTable.tsx
@@ -415,7 +415,10 @@ const PlaybackTable = () => {
         }
 
         if (attemptTypeFilter !== "all") {
-          pagination.type = attemptTypeFilter;
+          // API expects capitalized attempt type values
+          pagination.type =
+            attemptTypeFilter.charAt(0).toUpperCase() +
+            attemptTypeFilter.slice(1).toLowerCase();
         }
 
         if (dateRange[0]) {
@@ -613,8 +616,8 @@ const PlaybackTable = () => {
             }}
           >
             <MenuItem value="all">All Attempt Type</MenuItem>
-            <MenuItem value="practice">Practice</MenuItem>
-            <MenuItem value="test">Test</MenuItem>
+            <MenuItem value="Practice">Practice</MenuItem>
+            <MenuItem value="Test">Test</MenuItem>
           </Select>
         </Stack>
       </Stack>


### PR DESCRIPTION
## Summary
- ensure attempt type filter sends capitalized value to API
- update attempt type dropdown values accordingly

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_683da3a9f3288322acdac30300cad9d7