### PR TITLE
Set playback default date filter to all time

### DIFF
--- a/src/components/dashboard/trainee/playback/PlaybackTable.tsx
+++ b/src/components/dashboard/trainee/playback/PlaybackTable.tsx
@@ -60,10 +60,8 @@ const PlaybackTable = () => {
   const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [dateRange, setDateRange] = useState<DateRange<Dayjs>>([
-    dayjs().subtract(6, "day"),
-    dayjs(),
-  ]);
+  // Default to showing all available data
+  const [dateRange, setDateRange] = useState<DateRange<Dayjs>>([null, null]);
   const [simTypeFilter, setSimTypeFilter] = useState("all");
   const [levelFilter, setLevelFilter] = useState("all");
   const [attemptTypeFilter, setAttemptTypeFilter] = useState("all");


### PR DESCRIPTION
## Summary
- default playback table DateSelector to `All Time`

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_683da52328b0832282e45da67d4c6969