### PR TITLE
Fix playback controls position

### DIFF
--- a/src/components/dashboard/trainee/playback/detail/Playback.tsx
+++ b/src/components/dashboard/trainee/playback/detail/Playback.tsx
@@ -6,7 +6,7 @@ import {
   fetchPlaybackByIdRowData,
   FetchPlaybackByIdRowDataResponse,
 } from "../../../../../services/playback";
-import { Stack } from "@mui/material";
+import { Stack, Box } from "@mui/material";
 import PlaybackDetails from "./PlaybackDetails";
 
 interface PlaybackProps {
@@ -69,10 +69,16 @@ const Playback = ({ attepmtId, showDetails }: PlaybackProps) => {
 
   return (
     <>
-      <Stack direction="row" spacing={2}>
-        <Stack flex={1} spacing={2}>
+      <Stack direction="row" spacing={2} sx={{ height: '100%' }}>
+        <Stack
+          flex={1}
+          spacing={2}
+          sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+        >
           <PlaybackChat messages={messages} />
-          <PlaybackControls audioUrl={playbackData?.audioUrl || ""} />
+          <Box sx={{ mt: 'auto' }}>
+            <PlaybackControls audioUrl={playbackData?.audioUrl || ''} />
+          </Box>
         </Stack>
         {showDetails && playbackData ? (
           <PlaybackDetails playbackData={playbackData} />
@@ -82,5 +88,5 @@ const Playback = ({ attepmtId, showDetails }: PlaybackProps) => {
       </Stack>
     </>
   );
-};
+}; 
 export default Playback;

--- a/src/components/dashboard/trainee/playback/detail/PlaybackChat.tsx
+++ b/src/components/dashboard/trainee/playback/detail/PlaybackChat.tsx
@@ -8,7 +8,6 @@ import {
   Chip,
   Divider,
 } from "@mui/material";
-import PlaybackControls from "./PlaybackControls";
 
 interface Message {
   type: "agent" | "customer";

--- a/src/components/dashboard/trainee/playback/detail/PlaybackControls.tsx
+++ b/src/components/dashboard/trainee/playback/detail/PlaybackControls.tsx
@@ -89,6 +89,9 @@ const PlaybackControls = (props: PlaybackControlsProps) => {
         border: "1px solid #ddd",
         borderRadius: 2,
         boxShadow: "0 4px 10px rgba(0, 0, 0, 0.1)",
+        position: "sticky",
+        bottom: 0,
+        zIndex: 10,
       }}
     >
       <Stack spacing={2}>


### PR DESCRIPTION
## Summary
- keep playback controls stuck to bottom of screen
- remove unused import

## Testing
- `npm run lint` *(fails: Invalid option '--ext' because eslint.config.js uses new flat config)*

------
https://chatgpt.com/codex/tasks/task_e_683db98c9ce48322bbdad562ce365036