### PR TITLE
Load roles dynamically on admin dashboard

### DIFF
--- a/src/components/dashboard/admin/AdminDashboard.tsx
+++ b/src/components/dashboard/admin/AdminDashboard.tsx
@@ -50,6 +50,7 @@ import {
   fetchAdminDashboardStats,
   fetchAdminDashboardUserActivity,
 } from "../../../services/admin";
+import { fetchRoles } from "../../../services/roles";
 import { DateRange } from "@mui/x-date-pickers-pro";
 import dayjs, { Dayjs } from "dayjs";
 import DateSelector from "../../common/DateSelector";
@@ -525,6 +526,7 @@ const AdminDashboard = () => {
   const [division, setDivision] = useState("All Divisions");
   const [departments, setDepartments] = useState<string[]>([]);
   const [divisions, setDivisions] = useState<string[]>([]);
+  const [rolesList, setRolesList] = useState<string[]>([]);
   const [isLoadingDepartments, setIsLoadingDepartments] = useState(false);
   const [isLoadingDivisions, setIsLoadingDivisions] = useState(false);
   const [role, setRole] = useState("All Roles");
@@ -648,8 +650,18 @@ const AdminDashboard = () => {
       }
     };
 
+    const loadRoles = async () => {
+      try {
+        const data = await fetchRoles();
+        setRolesList(data.map((r) => r.name));
+      } catch (err) {
+        console.error("Failed to load roles:", err);
+      }
+    };
+
     loadDivisions();
     loadDepartments();
+    loadRoles();
   }, [currentWorkspaceId]);
 
   useEffect(() => {
@@ -730,6 +742,7 @@ const AdminDashboard = () => {
   };
 
   const handleRoleChange = (event: SelectChangeEvent<string>) => {
+    setRole(event.target.value);
     setUserActivityParams({
       ...userActivityParams,
       role: event.target.value,
@@ -922,18 +935,11 @@ const AdminDashboard = () => {
                   <MenuItem sx={menuItemSx} value="All Roles">
                     All Roles
                   </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Admin">
-                    Admin
-                  </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Manager">
-                    Manager
-                  </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Designer">
-                    Designer
-                  </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Trainee">
-                    Trainee
-                  </MenuItem>
+                  {rolesList.map((r) => (
+                    <MenuItem sx={menuItemSx} key={r} value={r}>
+                      {r}
+                    </MenuItem>
+                  ))}
                 </Select>
               </Stack>
             </Stack>
@@ -1062,18 +1068,11 @@ const AdminDashboard = () => {
                   <MenuItem sx={menuItemSx} value="All Roles">
                     All Roles
                   </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Admin">
-                    Admin
-                  </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Manager">
-                    Manager
-                  </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Designer">
-                    Designer
-                  </MenuItem>
-                  <MenuItem sx={menuItemSx} value="Trainee">
-                    Trainee
-                  </MenuItem>
+                  {rolesList.map((r) => (
+                    <MenuItem sx={menuItemSx} key={r} value={r}>
+                      {r}
+                    </MenuItem>
+                  ))}
                 </Select>
 
                 <Select

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -1,0 +1,20 @@
+import apiClient from "./api/interceptors";
+
+// Get the UAM API URL from environment variables
+const UAM_API_URL = import.meta.env.VITE_CORE_BACKEND_URL;
+const ROLES_URL = `${UAM_API_URL}/uam/api/simulator/roles`;
+
+export interface Role {
+  role_id: string;
+  name: string;
+}
+
+export const fetchRoles = async (): Promise<Role[]> => {
+  try {
+    const response = await apiClient.get(ROLES_URL);
+    return response.data || [];
+  } catch (error) {
+    console.error("Error fetching roles:", error);
+    return [];
+  }
+};


### PR DESCRIPTION
## Summary
- add new service to fetch roles from backend
- load role names in AdminDashboard
- populate role dropdowns using fetched roles

## Testing
- `npm run build`
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6841ab856b848322b930d1ad3d82f209