### PR TITLE
Fix pagination payload for admin table

### DIFF
--- a/src/components/dashboard/admin/AdminDashboard.tsx
+++ b/src/components/dashboard/admin/AdminDashboard.tsx
@@ -577,8 +577,8 @@ const AdminDashboard = () => {
       setError(null);
 
       const payload: AdminUsersTableRequest = {
-        page: page + 1,
-        limit: 5,
+        page,
+        limit: rowsPerPage,
         search: searchQuery || undefined,
         division: division !== "All Divisions" ? division : undefined,
         department: department !== "All Department" ? department : undefined,


### PR DESCRIPTION
## Summary
- correct pagination and limit parameters when fetching admin users table

## Testing
- `npm run lint` *(fails: Invalid option '--ext' because eslint.config.js uses new CLI)*

------
https://chatgpt.com/codex/tasks/task_e_6842c82ff0608322a63078ae7a85eb9b