### PR TITLE
Add role/date filters for engagement metrics

### DIFF
--- a/src/components/dashboard/admin/AdminDashboard.tsx
+++ b/src/components/dashboard/admin/AdminDashboard.tsx
@@ -62,6 +62,7 @@ import { LineChart, PieChart } from "@mui/x-charts";
 import {
   fetchActiveUserMetricsHistory,
   ActiveUserMetricsHistoryItem,
+  ActiveUserMetricsHistoryRequest,
 } from "../../../services/metrics";
 // import { fetchAdminDashboardData, fetchUserActivityLog } from '../../../services/admin';
 // import { adminDashboardData } from '../../../services/mockData/adminDashboard';
@@ -622,11 +623,18 @@ const AdminDashboard = () => {
 
   const loadUserEngagementMetrics = async () => {
     try {
-      const days =
-        engagementDateRange[0] && engagementDateRange[1]
-          ? engagementDateRange[1].diff(engagementDateRange[0], "day") + 1
-          : 30;
-      const { metrics } = await fetchActiveUserMetricsHistory(days);
+      const params: ActiveUserMetricsHistoryRequest = {
+        role: engagementRole !== "All Roles" ? engagementRole : undefined,
+      };
+
+      if (engagementDateRange[0] && engagementDateRange[1]) {
+        params.start_time = engagementDateRange[0].toISOString();
+        params.end_time = engagementDateRange[1].toISOString();
+      } else {
+        params.days = 30;
+      }
+
+      const { metrics } = await fetchActiveUserMetricsHistory(params);
       const mapped = metrics.map((m) => ({
         date: dayjs(m.date).format("MM/DD"),
         daily: m.daily_active_users,
@@ -689,7 +697,7 @@ const AdminDashboard = () => {
 
   useEffect(() => {
     loadUserEngagementMetrics();
-  }, [engagementDateRange]);
+  }, [engagementDateRange, engagementRole]);
 
   // useEffect(() => {
   //   const loadUserActivity = async () => {

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -11,12 +11,25 @@ export interface ActiveUserMetricsHistoryResponse {
   metrics: ActiveUserMetricsHistoryItem[];
 }
 
+export interface ActiveUserMetricsHistoryRequest {
+  days?: number;
+  role?: string;
+  start_time?: string;
+  end_time?: string;
+}
+
 export const fetchActiveUserMetricsHistory = async (
-  days: number
+  params: ActiveUserMetricsHistoryRequest
 ): Promise<ActiveUserMetricsHistoryResponse> => {
   try {
+    const query: Record<string, string | number | undefined> = {};
+    if (params.days !== undefined) query.days = params.days;
+    if (params.role) query.role = params.role;
+    if (params.start_time) query.start_time = params.start_time;
+    if (params.end_time) query.end_time = params.end_time;
+
     const response = await apiClient.get("/metrics/active-users/history", {
-      params: { days },
+      params: query,
     });
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- allow passing role & date range when fetching active user metrics
- send selected filters from `AdminDashboard` to the metrics API
- reload engagement chart when role selection changes

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842cc2cbad083228e22c8b533f44b26