### PR TITLE
Fix rolesList ReferenceError in AdminDashboard

### DIFF
--- a/src/components/dashboard/admin/AdminDashboard.tsx
+++ b/src/components/dashboard/admin/AdminDashboard.tsx
@@ -501,6 +501,7 @@ const AdminDashboard = () => {
     dayjs(),
   ]);
   const [engagementRole, setEngagementRole] = useState("All Roles");
+  const [rolesList, setRolesList] = useState<string[]>([]);
 
   const [userEngagementData, setUserEngagementData] = useState<
     ActiveUserMetricsHistoryItem[]
@@ -523,6 +524,7 @@ const AdminDashboard = () => {
           fetchRoles(),
         ]);
         const roleNames = roles.map((r) => r.name);
+        setRolesList(roleNames);
         const augmented = addMissingRoles(stats, roleNames);
         setDashboardStats(augmented);
       } catch (error) {


### PR DESCRIPTION
## Summary
- fix undefined `rolesList` error by adding state and populating with API data

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6842d8972754832290da865985a3f446